### PR TITLE
Set Id to FirebaseId and Fix Multiple Sign-on issue

### DIFF
--- a/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
+++ b/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
@@ -1,6 +1,7 @@
 package ch.epfl.favo.auth;
 
 import android.annotation.SuppressLint;
+import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -27,8 +28,6 @@ import ch.epfl.favo.map.Locator;
 import ch.epfl.favo.user.User;
 import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.DependencyFactory;
-
-import android.provider.Settings.Secure;
 
 @SuppressLint("NewApi")
 public class SignInActivity extends AppCompatActivity {
@@ -143,8 +142,7 @@ public class SignInActivity extends AppCompatActivity {
       FirebaseUser currentUser = DependencyFactory.getCurrentFirebaseUser();
       String currentUserId = currentUser.getUid();
       CompletableFuture<User> userFuture = UserUtil.getSingleInstance().findUser(currentUserId);
-      String deviceId =
-          Secure.getString(getApplicationContext().getContentResolver(), Secure.ANDROID_ID);
+      String deviceId = DependencyFactory.getDeviceId(getApplicationContext().getContentResolver());
 
       // Add/update user info depending on db status
       userFuture.whenComplete(

--- a/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
+++ b/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
@@ -1,7 +1,7 @@
 package ch.epfl.favo.auth;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
-import android.location.Location;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -17,15 +17,20 @@ import com.google.firebase.auth.FirebaseUser;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import ch.epfl.favo.BuildConfig;
 import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
+import ch.epfl.favo.common.FavoLocation;
 import ch.epfl.favo.map.Locator;
 import ch.epfl.favo.user.User;
 import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.DependencyFactory;
 
+import android.provider.Settings.Secure;
+
+@SuppressLint("NewApi")
 public class SignInActivity extends AppCompatActivity {
 
   private static final int RC_SIGN_IN = 123;
@@ -134,17 +139,31 @@ public class SignInActivity extends AppCompatActivity {
     if (resultCode == RESULT_OK) {
       // Successfully signed in
 
-
+      // Lookup user with Firebase Id in Db to extract details
       FirebaseUser currentUser = DependencyFactory.getCurrentFirebaseUser();
-      String name = currentUser.getDisplayName();
-      String email = currentUser.getEmail();
-      Uri photo = currentUser.getPhotoUrl();
-      Location loc = mGpsTracker.getLocation();
-      String deviceId = currentUser.getUid();
-      User user = new User(name, email, deviceId, null, loc);
+      String currentUserId = currentUser.getUid();
+      CompletableFuture<User> userFuture = UserUtil.getSingleInstance().findUser(currentUserId);
+      String deviceId =
+          Secure.getString(getApplicationContext().getContentResolver(), Secure.ANDROID_ID);
 
-      UserUtil.getSingleInstance().postAccount(user);
-      UserUtil.getSingleInstance().retrieveUserRegistrationToken(user);
+      // Add/update user info depending on db status
+      userFuture.whenComplete(
+          (user, e) -> {
+            if (user == null) {
+              String name = currentUser.getDisplayName();
+              String email = currentUser.getEmail();
+              Uri photo = currentUser.getPhotoUrl();
+              FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
+              user = new User(currentUserId, name, email, deviceId, null, loc);
+            } else if (!deviceId.equals(user.getDeviceId())) {
+              if (!deviceId.equals(user.getDeviceId())) {
+                user.setDeviceId(deviceId);
+              }
+            }
+
+            UserUtil.getSingleInstance().postAccount(user);
+            UserUtil.getSingleInstance().retrieveUserRegistrationToken(user);
+          });
 
       startMainActivity();
     }

--- a/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
+++ b/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
@@ -161,7 +161,7 @@ public class SignInActivity extends AppCompatActivity {
               }
             }
 
-            UserUtil.getSingleInstance().postAccount(user);
+            UserUtil.getSingleInstance().postUser(user);
             UserUtil.getSingleInstance().retrieveUserRegistrationToken(user);
           });
 

--- a/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
+++ b/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
@@ -153,9 +153,7 @@ public class SignInActivity extends AppCompatActivity {
               FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
               user = new User(currentUserId, name, email, deviceId, null, loc);
             } else if (!deviceId.equals(user.getDeviceId())) {
-              if (!deviceId.equals(user.getDeviceId())) {
-                user.setDeviceId(deviceId);
-              }
+              user.setDeviceId(deviceId);
             }
 
             UserUtil.getSingleInstance().postUser(user);

--- a/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
+++ b/app/src/main/java/ch/epfl/favo/auth/SignInActivity.java
@@ -1,7 +1,6 @@
 package ch.epfl.favo.auth;
 
 import android.annotation.SuppressLint;
-import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;

--- a/app/src/main/java/ch/epfl/favo/common/DatabaseWrapper.java
+++ b/app/src/main/java/ch/epfl/favo/common/DatabaseWrapper.java
@@ -24,7 +24,7 @@ public class DatabaseWrapper {
 
   // final fields regarding ID generation
   private static final String ID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  private static final int ID_LENGTH = 25;
+  private static final int ID_LENGTH = 28;
 
   private DatabaseWrapper() {
     FirebaseFirestore.setLoggingEnabled(true);
@@ -64,11 +64,8 @@ public class DatabaseWrapper {
     getCollectionReference(collection).document(key).delete();
   }
 
-  static void updateDocument(
-      String key, Map<String, Object> updates, String collection) {
+  static void updateDocument(String key, Map<String, Object> updates, String collection) {
     getCollectionReference(collection).document(key).update(updates);
-
-
   }
 
   static <T extends Document> CompletableFuture<T> getDocument(

--- a/app/src/main/java/ch/epfl/favo/common/DatabaseWrapper.java
+++ b/app/src/main/java/ch/epfl/favo/common/DatabaseWrapper.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -77,8 +77,8 @@ public class Favor implements Parcelable, Document {
       FavoLocation location,
       Status statusId) {
 
-    String id = DatabaseWrapper.generateRandomId();
-    this.id = id;
+    this.id = DatabaseWrapper.generateRandomId();
+    ;
     this.title = title;
     this.description = description;
     this.requesterId = requesterId;
@@ -88,7 +88,8 @@ public class Favor implements Parcelable, Document {
     this.accepterId = null;
   }
 
-  public Favor( // includes id
+  // Constructor to override default generated Id
+  public Favor(
       String id,
       String title,
       String description,

--- a/app/src/main/java/ch/epfl/favo/user/User.java
+++ b/app/src/main/java/ch/epfl/favo/user/User.java
@@ -3,11 +3,11 @@ package ch.epfl.favo.user;
 import android.location.Location;
 
 import java.time.LocalDate;
+import java.util.Date;
 import java.util.Map;
 
-import ch.epfl.favo.common.DatabaseWrapper;
 import ch.epfl.favo.common.Document;
-import ch.epfl.favo.common.NotImplementedException;
+import ch.epfl.favo.common.FavoLocation;
 
 /**
  * This class contains all the relevant information about users TODO: It should implement parcelable
@@ -20,20 +20,20 @@ public class User implements Document {
   private String email;
   private String deviceId;
   private String notificationId;
-  private LocalDate birthDate;
-  private Location location;
+  private Date birthDate;
+  private FavoLocation location;
   private int activeAcceptingFavors;
   private int activeRequestingFavors;
 
   public User() {}
 
-  public User(String name, String email, String deviceId, LocalDate birthDate, Location location) {
-    this.id = DatabaseWrapper.generateRandomId();
+  public User(String id, String name, String email, String deviceId, LocalDate birthDate, FavoLocation location) {
+    this.id = id;
     this.name = name;
     this.email = email;
     this.deviceId = deviceId;
     this.notificationId = null;
-    this.birthDate = birthDate;
+    this.birthDate = new Date();;
     this.location = location;
     this.activeAcceptingFavors = 0;
     this.activeRequestingFavors = 0;
@@ -66,7 +66,7 @@ public class User implements Document {
     return notificationId;
   }
 
-  public LocalDate getBirthDate() {
+  public Date getBirthDate() {
     return birthDate;
   }
 
@@ -82,19 +82,21 @@ public class User implements Document {
     return activeRequestingFavors;
   }
 
-  void setActiveAcceptingFavors(int activeAcceptingFavors) {
+  public void setActiveAcceptingFavors(int activeAcceptingFavors) {
     this.activeAcceptingFavors = activeAcceptingFavors;
   }
 
-  void setActiveRequestingFavors(int activeRequestingFavors) {
+  public void setActiveRequestingFavors(int activeRequestingFavors) {
     this.activeRequestingFavors = activeRequestingFavors;
   }
 
-  void setNotificationId(String notificationId) {
+  public void setNotificationId(String notificationId) {
     this.notificationId = notificationId;
   }
 
-  void setLocation(Location location) {
+  public void setDeviceId(String deviceId) { this.deviceId = deviceId; }
+
+  void setLocation(FavoLocation location) {
     this.location = location;
   }
 

--- a/app/src/main/java/ch/epfl/favo/user/User.java
+++ b/app/src/main/java/ch/epfl/favo/user/User.java
@@ -27,13 +27,19 @@ public class User implements Document {
 
   public User() {}
 
-  public User(String id, String name, String email, String deviceId, LocalDate birthDate, FavoLocation location) {
+  public User(
+      String id,
+      String name,
+      String email,
+      String deviceId,
+      Date birthDate,
+      FavoLocation location) {
     this.id = id;
     this.name = name;
     this.email = email;
     this.deviceId = deviceId;
     this.notificationId = null;
-    this.birthDate = new Date();;
+    this.birthDate = birthDate;
     this.location = location;
     this.activeAcceptingFavors = 0;
     this.activeRequestingFavors = 0;
@@ -94,7 +100,9 @@ public class User implements Document {
     this.notificationId = notificationId;
   }
 
-  public void setDeviceId(String deviceId) { this.deviceId = deviceId; }
+  public void setDeviceId(String deviceId) {
+    this.deviceId = deviceId;
+  }
 
   void setLocation(FavoLocation location) {
     this.location = location;

--- a/app/src/main/java/ch/epfl/favo/user/User.java
+++ b/app/src/main/java/ch/epfl/favo/user/User.java
@@ -2,7 +2,6 @@ package ch.epfl.favo.user;
 
 import android.location.Location;
 
-import java.time.LocalDate;
 import java.util.Date;
 import java.util.Map;
 

--- a/app/src/main/java/ch/epfl/favo/user/UserUtil.java
+++ b/app/src/main/java/ch/epfl/favo/user/UserUtil.java
@@ -41,7 +41,7 @@ public class UserUtil {
    * @param user A user object.
    * @throws RuntimeException Unable to post to DB.
    */
-  public void postAccount(User user) throws RuntimeException {
+  public void postUser(User user) throws RuntimeException {
     try {
       collection.addDocument(user);
       currentUserId = user.getId();

--- a/app/src/main/java/ch/epfl/favo/user/UserUtil.java
+++ b/app/src/main/java/ch/epfl/favo/user/UserUtil.java
@@ -1,5 +1,6 @@
 package ch.epfl.favo.user;
 
+import android.content.res.Resources;
 import android.location.Location;
 import android.util.Log;
 
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import ch.epfl.favo.common.DatabaseUpdater;
 import ch.epfl.favo.common.NotImplementedException;
@@ -45,6 +47,17 @@ public class UserUtil {
       currentUserId = user.getId();
     } catch (RuntimeException e) {
       Log.d(TAG, "unable to add document to db.");
+    }
+  }
+
+  /** @param id A FireBase Uid to search for in Users table. */
+  public CompletableFuture<User> findUser(String id) throws Resources.NotFoundException {
+
+    try {
+      return collection.getDocument(id);
+    } catch (Exception e) {
+      Log.d(TAG, "unable to find document in db.");
+      throw new Resources.NotFoundException();
     }
   }
 

--- a/app/src/main/java/ch/epfl/favo/util/DependencyFactory.java
+++ b/app/src/main/java/ch/epfl/favo/util/DependencyFactory.java
@@ -1,10 +1,12 @@
 package ch.epfl.favo.util;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.location.LocationManager;
 import android.os.Build;
 import android.provider.MediaStore;
+import android.provider.Settings;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -31,11 +33,13 @@ public class DependencyFactory {
   private static boolean offlineMode = false;
   private static boolean testMode = false;
   private static CompletableFuture currentCompletableFuture;
+  private static Settings.Secure deviceSettings;
 
   @RequiresApi(api = Build.VERSION_CODES.M)
   public static boolean isOfflineMode(Context context) {
     return offlineMode || CommonTools.isOffline(context);
   }
+
   public static boolean isTestMode() {
     return testMode;
   }
@@ -121,6 +125,19 @@ public class DependencyFactory {
       return currentFirestore;
     }
     return FirebaseFirestore.getInstance();
+  }
+
+  @VisibleForTesting
+  public static void setDeviceId(Settings.Secure dependency) {
+    testMode = true;
+    deviceSettings = dependency;
+  }
+
+  public static String getDeviceId(@Nullable ContentResolver contentResolver) {
+    if (testMode || contentResolver == null) {
+      return "22f523fgg3";
+    }
+    return deviceSettings.getString(contentResolver, Settings.Secure.ANDROID_ID);
   }
 
   public static <T> CompletableFuture<T> getCurrentCompletableFuture() {

--- a/app/src/main/java/ch/epfl/favo/util/DependencyFactory.java
+++ b/app/src/main/java/ch/epfl/favo/util/DependencyFactory.java
@@ -127,12 +127,6 @@ public class DependencyFactory {
     return FirebaseFirestore.getInstance();
   }
 
-  @VisibleForTesting
-  public static void setDeviceId(Settings.Secure dependency) {
-    testMode = true;
-    deviceSettings = dependency;
-  }
-
   public static String getDeviceId(@Nullable ContentResolver contentResolver) {
     if (testMode || contentResolver == null) {
       return "22f523fgg3";

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/TestConstants.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/TestConstants.java
@@ -1,6 +1,5 @@
 package ch.epfl.favo;
 
-import android.location.Location;
 import android.net.Uri;
 
 import ch.epfl.favo.common.DatabaseWrapper;
@@ -15,7 +14,6 @@ public class TestConstants {
   public static final String EMAIL = "test@example.com";
   public static final String NAME = "Test Testerson";
   public static final String USERNAME = "testerson123";
-  public static final String PASSWORD = "fh498f30cpe";
   public static final String PROVIDER = "test provider";
   public static final Uri PHOTO_URI = Uri.parse("http://example.com/profile.png");
 
@@ -33,5 +31,4 @@ public class TestConstants {
   public static final String NOTIFICATION_TITLE = "title";
   public static final String NOTIFICATION_BODY = "body";
   public static final String FAVOR_ID = "WEZDZQD78A5SI5Q790SZAL7FW";
-
 }

--- a/app/src/test/java/ch/epfl/favo/auth/SignInActivityTest.java
+++ b/app/src/test/java/ch/epfl/favo/auth/SignInActivityTest.java
@@ -1,16 +1,30 @@
 package ch.epfl.favo.auth;
 
+import android.content.ContentResolver;
+import android.content.Context;
+import android.provider.Settings;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.concurrent.CompletableFuture;
+
 import ch.epfl.favo.FakeFirebaseUser;
+import ch.epfl.favo.common.CollectionWrapper;
+import ch.epfl.favo.user.User;
 import ch.epfl.favo.util.DependencyFactory;
+import ch.epfl.favo.view.MockDatabaseWrapper;
 
 import static android.app.Activity.RESULT_OK;
 import static ch.epfl.favo.TestConstants.EMAIL;
 import static ch.epfl.favo.TestConstants.NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class SignInActivityTest {
 
@@ -18,6 +32,7 @@ public class SignInActivityTest {
   // the result action of the sign-in is handled
 
   private SignInActivity spy;
+  private Context contextMock = mock(Context.class);
 
   @Before
   public void setup() {
@@ -39,10 +54,13 @@ public class SignInActivityTest {
     spy.onActivityResult(123, 10, null);
   }
 
-  //  @Test
-  //  public void testOnActivityResult_resultOk() {
-  //    Mockito.doNothing().when(spy).handleSignInResponse(0);
-  //    DependencyFactory.setCurrentFirebaseUser(new FakeFirebaseUser(NAME, EMAIL, null, null));
-  //    spy.onActivityResult(123, RESULT_OK, null);
-  //  }
+  @Test
+  public void testOnActivityResult_resultOk() {
+
+    Mockito.doNothing().when(spy).handleSignInResponse(anyInt());
+    DependencyFactory.setCurrentCollectionWrapper(new MockDatabaseWrapper());
+    DependencyFactory.setCurrentFirebaseUser(new FakeFirebaseUser(NAME, EMAIL, null, null));
+
+    spy.onActivityResult(123, RESULT_OK, null);
+  }
 }

--- a/app/src/test/java/ch/epfl/favo/auth/SignInActivityTest.java
+++ b/app/src/test/java/ch/epfl/favo/auth/SignInActivityTest.java
@@ -1,30 +1,18 @@
 package ch.epfl.favo.auth;
 
-import android.content.ContentResolver;
-import android.content.Context;
-import android.provider.Settings;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.concurrent.CompletableFuture;
-
 import ch.epfl.favo.FakeFirebaseUser;
-import ch.epfl.favo.common.CollectionWrapper;
-import ch.epfl.favo.user.User;
 import ch.epfl.favo.util.DependencyFactory;
 import ch.epfl.favo.view.MockDatabaseWrapper;
 
 import static android.app.Activity.RESULT_OK;
 import static ch.epfl.favo.TestConstants.EMAIL;
 import static ch.epfl.favo.TestConstants.NAME;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 public class SignInActivityTest {
 
@@ -32,7 +20,6 @@ public class SignInActivityTest {
   // the result action of the sign-in is handled
 
   private SignInActivity spy;
-  private Context contextMock = mock(Context.class);
 
   @Before
   public void setup() {

--- a/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.mockito.Mockito;
 
-import java.time.LocalDate;
+import java.util.Date;
 
 import ch.epfl.favo.TestConstants;
 import ch.epfl.favo.common.CollectionWrapper;
@@ -29,17 +29,10 @@ import static org.mockito.ArgumentMatchers.any;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 public class UserUnitTests {
-  private User user;
-
-  @Before
-  public void setup() {
-    user = new User();
-  }
 
   @Test
   public void userCanRemoveDetailsFromDatabase() {
 
-    String userId = TestConstants.USER_ID;
     assertThrows(NotImplementedException.class, () -> UserUtil.getSingleInstance().deleteAccount());
   }
 
@@ -50,7 +43,7 @@ public class UserUnitTests {
     String name = TestConstants.NAME;
     String email = TestConstants.EMAIL;
     String deviceId = TestConstants.DEVICE_ID;
-    LocalDate birthDate = LocalDate.of(1994, 11, 8);
+    Date birthDate = new Date();
     FavoLocation location = TestConstants.LOCATION;
 
     User user = new User(id, name, email, deviceId, birthDate, location);
@@ -74,8 +67,7 @@ public class UserUnitTests {
     int activeRequestingFavors = 4;
     String temporaryNotificationId = "temporaryNotificationId";
     String temporaryDeviceId = "temporaryDeviceId";
-    String providerName = "newProvider";
-    FavoLocation newLoc = new FavoLocation(providerName);
+    FavoLocation newLoc = new FavoLocation();
 
     user.setActiveAcceptingFavors(activeAcceptingFavors);
     user.setActiveRequestingFavors(activeRequestingFavors);
@@ -85,7 +77,6 @@ public class UserUnitTests {
 
     assertEquals(activeAcceptingFavors, user.getActiveAcceptingFavors());
     assertEquals(activeRequestingFavors, user.getActiveRequestingFavors());
-    assertEquals(providerName, newLoc.getProvider());
     assertEquals(temporaryNotificationId, user.getNotificationId());
     assertEquals(temporaryDeviceId, user.getDeviceId());
   }

--- a/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 
 import ch.epfl.favo.TestConstants;
 import ch.epfl.favo.common.CollectionWrapper;
+import ch.epfl.favo.common.FavoLocation;
 import ch.epfl.favo.common.NotImplementedException;
 import ch.epfl.favo.util.TestUtil;
 
@@ -45,13 +46,14 @@ public class UserUnitTests {
   @Test
   public void userGettersReturnCorrectValues() {
 
+    String id = TestConstants.USER_ID;
     String name = TestConstants.NAME;
     String email = TestConstants.EMAIL;
     String deviceId = TestConstants.DEVICE_ID;
     LocalDate birthDate = LocalDate.of(1994, 11, 8);
-    Location location = TestConstants.LOCATION;
+    FavoLocation location = TestConstants.LOCATION;
 
-    User user = new User(name, email, deviceId, birthDate, location);
+    User user = new User(id, name, email, deviceId, birthDate, location);
 
     assertEquals(name, user.getName());
     assertEquals(email, user.getEmail());
@@ -70,14 +72,22 @@ public class UserUnitTests {
     User user = new User();
     int activeAcceptingFavors = 3;
     int activeRequestingFavors = 4;
-    String temporaryId = "temporaryId";
+    String temporaryNotificationId = "temporaryNotificationId";
+    String temporaryDeviceId = "temporaryDeviceId";
+    String providerName = "newProvider"
+    FavoLocation newLoc = new FavoLocation(providerName);
+
     user.setActiveAcceptingFavors(activeAcceptingFavors);
     user.setActiveRequestingFavors(activeRequestingFavors);
-    user.setNotificationId(temporaryId);
+    user.setNotificationId(temporaryNotificationId);
+    user.setDeviceId(temporaryDeviceId);
+    user.setLocation(newLoc);
 
     assertEquals(activeAcceptingFavors, user.getActiveAcceptingFavors());
     assertEquals(activeRequestingFavors, user.getActiveRequestingFavors());
-    assertEquals(temporaryId, user.getNotificationId());
+    assertEquals(providerName, newLoc.getProvider());
+    assertEquals(temporaryNotificationId, user.getNotificationId());
+    assertEquals(temporaryDeviceId, user.getDeviceId());
   }
 
   @Test
@@ -107,12 +117,13 @@ public class UserUnitTests {
     CollectionWrapper mock = Mockito.mock(CollectionWrapper.class);
     Mockito.doNothing().when(mock).addDocument(any(User.class));
 
+    String id = TestConstants.USER_ID;
     String name = TestConstants.NAME;
     String email = TestConstants.EMAIL;
     String deviceId = TestConstants.DEVICE_ID;
-    Location location = TestConstants.LOCATION;
+    FavoLocation location = TestConstants.LOCATION;
 
-    User user = new User(name, email, deviceId, null, location);
+    User user = new User(id, name, email, deviceId, null, location);
     UserUtil.getSingleInstance().postAccount(user);
 
     assertNotNull(user);

--- a/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
@@ -74,7 +74,7 @@ public class UserUnitTests {
     int activeRequestingFavors = 4;
     String temporaryNotificationId = "temporaryNotificationId";
     String temporaryDeviceId = "temporaryDeviceId";
-    String providerName = "newProvider"
+    String providerName = "newProvider";
     FavoLocation newLoc = new FavoLocation(providerName);
 
     user.setActiveAcceptingFavors(activeAcceptingFavors);

--- a/app/src/test/java/ch/epfl/favo/util/CommonToolsTests.java
+++ b/app/src/test/java/ch/epfl/favo/util/CommonToolsTests.java
@@ -24,7 +24,7 @@ public class CommonToolsTests {
 
   @Test
   public void databaseUtilCorrectlyGeneratesIds() {
-    int ID_LENGTH = 25;
+    int ID_LENGTH = 28;
     String id1 = DatabaseWrapper.generateRandomId();
     String id2 = DatabaseWrapper.generateRandomId();
     assertEquals(ID_LENGTH, id1.length());


### PR DESCRIPTION
This PR fixes issue #135 and now correctly sets the database Id for each user to be the FirebaseUser Id of that given user. 
It also correctly fetches user deviceId's now and handles the multiple sign-on issue in which a user logs in from the same device and has multiple backend entries. 
The notification Id is now correctly updated with the FavoLocation on every user sign-in. 
This PR also puts minor changes in to the User class to get CompletableFutures working for User objects.