### PR TITLE
Hookup Favor flow to backend db calls

### DIFF
--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -175,8 +175,8 @@ public class Favor implements Parcelable, Document {
     return postedTime;
   }
 
-  void setAccepterID(String accepterID) {
-    this.accepterId = accepterID;
+  void setAccepterID(String accepterId) {
+    this.accepterId = accepterId;
   }
 
   /**

--- a/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
+++ b/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
@@ -1,9 +1,11 @@
 package ch.epfl.favo.favor;
 
+import android.annotation.SuppressLint;
 import android.location.Location;
 import android.util.Log;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import ch.epfl.favo.common.DatabaseUpdater;
@@ -13,9 +15,9 @@ import ch.epfl.favo.util.DependencyFactory;
 /*
 This models the favor request.
 */
+@SuppressLint("NewApi")
 public class FavorUtil {
   private static final String TAG = "FavorUtil";
-  private static final String FAVOR_COLLECTION = "favors";
   private static final FavorUtil SINGLE_INSTANCE = new FavorUtil();
   private static DatabaseUpdater collection =
       DependencyFactory.getCurrentCollectionWrapper("favors", Favor.class);
@@ -43,6 +45,31 @@ public class FavorUtil {
       collection.addDocument(favor);
     } catch (RuntimeException e) {
       Log.d(TAG, "unable to add document to db.");
+    }
+  }
+
+  /**
+   * @param favorId the id of the favor to retrieve from DB.
+   * @return CompletableFuture<Favor>
+   */
+  public CompletableFuture<Favor> retrieveFavor(String favorId) {
+    try {
+      return collection.getDocument(favorId);
+    } catch (RuntimeException e) {
+      Log.d(TAG, "unable to retrieve document from db.");
+    }
+    return new CompletableFuture<>();
+  }
+
+  /**
+   * @param favorId the id of the favor to retrieve from DB.
+   * @return CompletableFuture<Favor>
+   */
+  public void updateFavor(String favorId, Map<String, Object> updates) {
+    try {
+      collection.updateDocument(favorId, updates);
+    } catch (RuntimeException e) {
+      Log.d(TAG, "unable to retrieve document from db.");
     }
   }
 
@@ -113,9 +140,5 @@ public class FavorUtil {
   public ArrayList<Favor> retrieveAllFavorsInGivenRadius(Location loc, double radius) {
 
     throw new NotImplementedException();
-  }
-
-  public CompletableFuture<Favor> retrieveFavor(String favorId) {
-    return collection.getDocument(favorId);
   }
 }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
@@ -9,13 +9,8 @@ import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import ch.epfl.favo.R;
 import ch.epfl.favo.favor.Favor;
-import ch.epfl.favo.favor.FavorUtil;
-import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.CommonTools;
 import ch.epfl.favo.util.FavorFragmentFactory;
 import ch.epfl.favo.view.ViewController;
@@ -36,25 +31,19 @@ public class FavorDetailView extends Fragment {
     View rootView = inflater.inflate(R.layout.fragment_favor_accept_view, container, false);
     Button confirmFavorBtn = rootView.findViewById(R.id.accept_button);
 
-    if (favor == null) {
-      favor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
-    }
-    displayFromFavor(rootView, favor);
-
     // Show snackbar when favor has been confirmed
     confirmFavorBtn.setOnClickListener(
         new View.OnClickListener() {
           @Override
           public void onClick(View v) {
             CommonTools.showSnackbar(getView(), getString(R.string.favor_respond_success_msg));
-
-            // Update accepterId in DB
-            String accepterId = UserUtil.currentUserId;
-            Map<String, Object> acceptedFavor = new HashMap<>();
-            acceptedFavor.put("accepterId", accepterId);
-            FavorUtil.getSingleInstance().updateFavor(favor.getId(), acceptedFavor);
           }
         });
+
+    if (favor == null) {
+      favor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
+    }
+    displayFromFavor(rootView, favor);
 
     return rootView;
   }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
@@ -9,8 +9,13 @@ import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import ch.epfl.favo.R;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorUtil;
+import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.CommonTools;
 import ch.epfl.favo.util.FavorFragmentFactory;
 import ch.epfl.favo.view.ViewController;
@@ -31,19 +36,25 @@ public class FavorDetailView extends Fragment {
     View rootView = inflater.inflate(R.layout.fragment_favor_accept_view, container, false);
     Button confirmFavorBtn = rootView.findViewById(R.id.accept_button);
 
+    if (favor == null) {
+      favor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
+    }
+    displayFromFavor(rootView, favor);
+
     // Show snackbar when favor has been confirmed
     confirmFavorBtn.setOnClickListener(
         new View.OnClickListener() {
           @Override
           public void onClick(View v) {
             CommonTools.showSnackbar(getView(), getString(R.string.favor_respond_success_msg));
+
+            // Update accepterId in DB
+            String accepterId = UserUtil.currentUserId;
+            Map<String, Object> acceptedFavor = new HashMap<>();
+            acceptedFavor.put("accepterId", accepterId);
+            FavorUtil.getSingleInstance().updateFavor(favor.getId(), acceptedFavor);
           }
         });
-
-    if (favor == null) {
-      favor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
-    }
-    displayFromFavor(rootView, favor);
 
     return rootView;
   }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -303,7 +303,7 @@ public class FavorRequestView extends Fragment {
   }
 
   /** Extracts favor data from and assigns it to currentFavor. */
-  private Favor getFavorFromView(Favor.Status status) {
+  private void getFavorFromView(Favor.Status status) {
 
     // Extract details and post favor to Firebase
     EditText titleElem = Objects.requireNonNull(getView()).findViewById(R.id.title_request_view);
@@ -312,12 +312,13 @@ public class FavorRequestView extends Fragment {
     String desc = descElem.getText().toString();
     FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
     Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, status);
+
+    // Updates the current favor
     if (currentFavor == null) {
       currentFavor = favor;
     } else {
       currentFavor.updateToOther(favor);
     }
-    return currentFavor;
   }
 
   /**

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -25,6 +25,8 @@ import androidx.fragment.app.Fragment;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import ch.epfl.favo.MainActivity;
@@ -88,7 +90,6 @@ public class FavorRequestView extends Fragment {
       currentFavor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
       displayFavorInfo(rootView);
       setFavorActivatedView(rootView);
-
     }
     return rootView;
   }
@@ -207,8 +208,10 @@ public class FavorRequestView extends Fragment {
     // update lists
     updateMainActivityLists(true);
     updateViewFromStatus(getView());
-    // TODO: add db call
     showSnackbar(getString(R.string.favor_edit_success_msg));
+
+    // DB call to update Favor details
+    FavorUtil.getSingleInstance().postFavor(currentFavor);
   }
 
   /** Updates favor on DB. Updates maps on main activity hides keyboard shows snackbar */
@@ -218,7 +221,11 @@ public class FavorRequestView extends Fragment {
     updateViewFromStatus(getView());
     // Show confirmation and minimize keyboard
     showSnackbar(getString(R.string.favor_cancel_success_msg));
-    // TODO: insert db call
+
+    // DB call to update status
+    Map<String, Object> statusUpdates = new HashMap<>();
+    statusUpdates.put("statusId", Favor.Status.CANCELLED_REQUESTER);
+    FavorUtil.getSingleInstance().updateFavor(currentFavor.getId(), statusUpdates);
   }
 
   private void updateMainActivityLists(boolean favorIsActive) {
@@ -296,20 +303,22 @@ public class FavorRequestView extends Fragment {
   }
 
   /** Extracts favor data from and assigns it to currentFavor. */
-  private void getFavorFromView(Favor.Status status) {
+  private Favor getFavorFromView(Favor.Status status) {
 
     // Extract details and post favor to Firebase
     EditText titleElem = Objects.requireNonNull(getView()).findViewById(R.id.title_request_view);
     EditText descElem = Objects.requireNonNull(getView()).findViewById(R.id.details);
     String title = titleElem.getText().toString();
     String desc = descElem.getText().toString();
+    Favor.Status FavorStatus = (status == null) ? Favor.Status.REQUESTED : status;
     FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
-    Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, Favor.Status.REQUESTED);
+    Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, FavorStatus);
     if (currentFavor == null) {
       currentFavor = favor;
     } else {
       currentFavor.updateToOther(favor);
     }
+    return currentFavor;
   }
 
   /**

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -310,9 +310,8 @@ public class FavorRequestView extends Fragment {
     EditText descElem = Objects.requireNonNull(getView()).findViewById(R.id.details);
     String title = titleElem.getText().toString();
     String desc = descElem.getText().toString();
-    Favor.Status FavorStatus = (status == null) ? Favor.Status.REQUESTED : status;
     FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
-    Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, FavorStatus);
+    Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, status);
     if (currentFavor == null) {
       currentFavor = favor;
     } else {

--- a/server/functions/index.js
+++ b/server/functions/index.js
@@ -85,7 +85,7 @@ exports.sendNotificationOnUpdate = functions.firestore
 
         // get new favor that has just been posted
         const newFavor = change.data();
-        var accepterID = newFavor.accepter;
+        var accepterId = newFavor.accepter;
         var favorTitle = newFavor.title;
         var usersIds = [];
 
@@ -103,7 +103,7 @@ exports.sendNotificationOnUpdate = functions.firestore
                 snapshot.forEach((doc) => {
                     var user = doc.data();
                     var userID = user.id;
-                    if (userID === accepterID) {
+                    if (userID === accepterId) {
                         usersIds.push(user.notificationId);
                     }
                 });


### PR DESCRIPTION
This PR fixes issue #138 and connects the FavorDetails and FavorRequest pages to the database.

- Calls to update/edit the details of the Favor now write to the database.
- Fixes bug with Favor status defaulting to "requested" on edit.
- Cancel button now updates Favor status to "cancelled_requestor" in db.
