### PR TITLE
Feature/accept flow

### DIFF
--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -149,6 +149,9 @@ public class AddFavorTest {
 
   @Test
   public void testCanHideKeyboardOnClickOutsideOfTextView() {
+    mockDatabaseWrapper.setMockDocument(FakeItemFactory.getFavor());
+    mockDatabaseWrapper.setThrowError(false);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     FavorRequestView currentFragment = new FavorRequestView();
     launchFragment(currentFragment);
     onView(withId(R.id.title_request_view)).perform(typeText("bla"));

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -36,6 +36,7 @@ import ch.epfl.favo.favor.FavorUtil;
 import ch.epfl.favo.util.DependencyFactory;
 import ch.epfl.favo.util.FavorFragmentFactory;
 import ch.epfl.favo.view.tabs.addFavor.FavorRequestView;
+import ch.epfl.favo.view.tabs.addFavor.FavorViewStatus;
 
 import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
@@ -163,7 +164,7 @@ public class AddFavorTest {
 
     // click outside of text view
     UiDevice device = UiDevice.getInstance(getInstrumentation());
-    device.click(10, device.getDisplayHeight()*3 / 4);
+    device.click(10, device.getDisplayHeight() * 3 / 4);
     // check button is visible
     onView(withId(R.id.edit_favor_button)).check(matches(isDisplayed()));
   }
@@ -213,7 +214,7 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(fakeFavor.getStatusId().getPrettyString())));
+        .check(matches(withText(FavorViewStatus.REQUESTED.getPrettyString())));
   }
 
   @Test
@@ -279,7 +280,7 @@ public class AddFavorTest {
     onView(withId(R.id.edit_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.cancel_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(fakeFavor.getStatusId().getPrettyString())));
+        .check(matches(withText(FavorViewStatus.SUCCESSFULLY_COMPLETED.getPrettyString())));
   }
 
   public void checkAcceptedView(Favor fakeFavor) {
@@ -289,7 +290,7 @@ public class AddFavorTest {
     onView(withId(R.id.cancel_favor_button)).check(matches((isEnabled())));
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(fakeFavor.getStatusId().getPrettyString())));
+        .check(matches(withText(FavorViewStatus.ACCEPTED.getPrettyString())));
   }
 
   @Test
@@ -341,7 +342,7 @@ public class AddFavorTest {
 
     // Check updated status string
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(Favor.Status.CANCELLED_REQUESTER.getPrettyString())));
+        .check(matches(withText(FavorViewStatus.CANCELLED_REQUESTER.getPrettyString())));
   }
 
   private void launchFragmentWithFakeFavor(Fragment fragment, Favor favor) {

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -155,6 +155,7 @@ public class AddFavorTest {
     onView(withId(R.id.request_button)).perform(click());
     getInstrumentation().waitForIdleSync();
     onView(withId(R.id.edit_favor_button)).perform(click());
+    getInstrumentation().waitForIdleSync();
     onView(withId(R.id.title_request_view)).perform(typeText("ble"));
 
     // click outside of text view

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -159,7 +159,7 @@ public class AddFavorTest {
 
     // click outside of text view
     UiDevice device = UiDevice.getInstance(getInstrumentation());
-    device.click(10, device.getDisplayHeight() / 2);
+    device.click(10, device.getDisplayHeight()*3 / 4);
     // check button is visible
     onView(withId(R.id.edit_favor_button)).check(matches(isDisplayed()));
   }

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
@@ -66,8 +66,7 @@ public class FavorDetailViewTest {
   public void setUp() {
     fakeFavor = FakeItemFactory.getFavor();
     UserUtil.currentUserId = "USER";
-    navController =
-        findNavController(mainActivityTestRule.getActivity(), R.id.nav_host_fragment);
+    navController = findNavController(mainActivityTestRule.getActivity(), R.id.nav_host_fragment);
     Bundle bundle = new Bundle();
     bundle.putParcelable(FavorFragmentFactory.FAVOR_ARGS, fakeFavor);
     navController.navigate(R.id.action_global_favorDetailView, bundle);
@@ -168,17 +167,14 @@ public class FavorDetailViewTest {
   @Test
   public void testFavorShowsFailureSnackbarIfCancelFails() throws InterruptedException {
     mockDatabaseWrapper.setMockDocument(fakeFavor);
-    CompletableFuture successfulResult = new CompletableFuture();
-    successfulResult.complete(null);
-    mockDatabaseWrapper.setMockResult(successfulResult);
+    mockDatabaseWrapper.setThrowError(false);
     FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     getInstrumentation().waitForIdleSync();
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
     Thread.sleep(500);
-    CompletableFuture failedResult = new CompletableFuture();
-    failedResult.completeExceptionally(new RuntimeException());
-    mockDatabaseWrapper.setMockResult(failedResult);
+    // now inject throwable to see reaction in the UI
+    mockDatabaseWrapper.setThrowError(true);
     FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     onView(withId(R.id.accept_button))
         .check(matches(withText(R.string.cancel_accept_button_display)))
@@ -195,13 +191,13 @@ public class FavorDetailViewTest {
   }
 
   @Test
-  public void testAcceptingFavorUpdatesListView(){
+  public void testAcceptingFavorUpdatesListView() {
     mockDatabaseWrapper.setMockDocument(fakeFavor);
     mockDatabaseWrapper.setThrowError(false);
     FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
-    //navigate to list view from main activity
+    // navigate to list view from main activity
     onView(withId(R.id.accept_button)).check(matches(isDisplayed())).perform(click());
-    //press back
+    // press back
     pressBack();
     getInstrumentation().waitForIdleSync();
     navController.navigate(R.id.action_nav_map_to_nav_favorlist);
@@ -210,12 +206,8 @@ public class FavorDetailViewTest {
     getInstrumentation().waitForIdleSync();
     onView(
             allOf(
-                    withId(R.id.fragment_favor_accept_view),
-                    withParent(withId(R.id.nav_host_fragment))))
-            .check(matches(isDisplayed()));
-
-
-
-
+                withId(R.id.fragment_favor_accept_view),
+                withParent(withId(R.id.nav_host_fragment))))
+        .check(matches(isDisplayed()));
   }
 }

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
@@ -20,6 +20,7 @@ import ch.epfl.favo.FakeItemFactory;
 import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorUtil;
 import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.DependencyFactory;
 import ch.epfl.favo.util.FavorFragmentFactory;
@@ -92,6 +93,7 @@ public class FavorDetailViewTest {
     successfulResult.complete(null);
     mockDatabaseWrapper.setMockDocument(fakeFavor); // set favor in db
     mockDatabaseWrapper.setMockResult(successfulResult);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
     // check snackbar shows
@@ -102,13 +104,15 @@ public class FavorDetailViewTest {
   }
 
   @Test
-  public void testAcceptButtonShowsFailSnackBar() {
+  public void testAcceptButtonShowsFailSnackBar() throws InterruptedException {
     CompletableFuture failedResult = new CompletableFuture();
     failedResult.completeExceptionally(new RuntimeException());
     // mockDatabaseWrapper.setMockDocument(fakeFavor); // set favor in db
     mockDatabaseWrapper.setMockResult(failedResult);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
+    Thread.sleep(500);
     // check snackbar shows
     onView(withId(com.google.android.material.R.id.snackbar_text))
         .check(matches(withText(R.string.update_favor_error)));
@@ -123,6 +127,7 @@ public class FavorDetailViewTest {
     Favor anotherFavorWithSameId = FakeItemFactory.getFavor();
     anotherFavorWithSameId.setStatusId(Favor.Status.ACCEPTED);
     mockDatabaseWrapper.setMockDocument(anotherFavorWithSameId);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
     // check snackbar shows
@@ -139,6 +144,7 @@ public class FavorDetailViewTest {
     CompletableFuture successfulResult = new CompletableFuture();
     successfulResult.complete(null);
     mockDatabaseWrapper.setMockResult(successfulResult);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     getInstrumentation().waitForIdleSync();
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
@@ -147,14 +153,14 @@ public class FavorDetailViewTest {
         .check(matches(withText(R.string.cancel_accept_button_display)))
         .perform(click());
     getInstrumentation().waitForIdleSync();
+    // check display is updated
+    onView(withId(R.id.status_text_accept_view))
+        .check(matches(withText(Favor.Status.CANCELLED_ACCEPTER.getPrettyString())));
 
     // check snackbar shows
     onView(withId(com.google.android.material.R.id.snackbar_text))
         .check(matches(withText(R.string.favor_cancel_success_msg)));
     getInstrumentation().waitForIdleSync();
-    // check display is updated
-    onView(withId(R.id.status_text_accept_view))
-        .check(matches(withText(Favor.Status.CANCELLED_ACCEPTER.getPrettyString())));
   }
 
   @Test
@@ -163,6 +169,7 @@ public class FavorDetailViewTest {
     CompletableFuture successfulResult = new CompletableFuture();
     successfulResult.complete(null);
     mockDatabaseWrapper.setMockResult(successfulResult);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     getInstrumentation().waitForIdleSync();
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
@@ -170,6 +177,7 @@ public class FavorDetailViewTest {
     CompletableFuture failedResult = new CompletableFuture();
     failedResult.completeExceptionally(new RuntimeException());
     mockDatabaseWrapper.setMockResult(failedResult);
+    FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
     onView(withId(R.id.accept_button))
         .check(matches(withText(R.string.cancel_accept_button_display)))
         .perform(click());

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
@@ -114,13 +114,15 @@ public class FavorDetailViewTest {
   }
   @Test
   public void testFavorFailsToBeAcceptedIfPreviouslyAccepted(){
-    fakeFavor.setStatusId(Favor.Status.ACCEPTED);
-    mockDatabaseWrapper.setMockDocument(fakeFavor);
+    onView(withId(R.id.accept_button)).check(matches(isDisplayed())).check(matches(withText(R.string.accept_favor)));
+    //Another user accepts favor
+    Favor anotherFavorWithSameId = FakeItemFactory.getFavor();
+    anotherFavorWithSameId.setStatusId(Favor.Status.ACCEPTED);
+    mockDatabaseWrapper.setMockDocument(anotherFavorWithSameId);
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
     // check snackbar shows
     onView(withId(com.google.android.material.R.id.snackbar_text))
-            .check(matches(withText("Failed to update")));
-
+            .check(matches(withText("Favor is no longer available")));
   }
 }

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
@@ -172,7 +172,7 @@ public class FavorDetailViewTest {
     getInstrumentation().waitForIdleSync();
     onView(withId(R.id.accept_button)).perform(click());
     getInstrumentation().waitForIdleSync();
-    Thread.sleep(500);
+
     // now inject throwable to see reaction in the UI
     mockDatabaseWrapper.setThrowError(true);
     FavorUtil.getSingleInstance().updateCollectionWrapper(mockDatabaseWrapper);
@@ -180,14 +180,16 @@ public class FavorDetailViewTest {
         .check(matches(withText(R.string.cancel_accept_button_display)))
         .perform(click());
     getInstrumentation().waitForIdleSync();
+    Thread.sleep(500);
+    // check display is updated
+    onView(withId(R.id.status_text_accept_view))
+            .check(matches(withText(Favor.Status.ACCEPTED.getPrettyString())));
 
     // check snackbar shows
     onView(withId(com.google.android.material.R.id.snackbar_text))
         .check(matches(withText(R.string.update_favor_error)));
     getInstrumentation().waitForIdleSync();
-    // check display is updated
-    onView(withId(R.id.status_text_accept_view))
-        .check(matches(withText(Favor.Status.ACCEPTED.getPrettyString())));
+
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorDetailViewTest.java
@@ -1,8 +1,8 @@
 package ch.epfl.favo.view;
 
-import android.location.Location;
+import android.os.Bundle;
 
-import androidx.fragment.app.FragmentTransaction;
+import androidx.navigation.NavController;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
@@ -13,15 +13,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.CompletableFuture;
+
 import ch.epfl.favo.FakeFirebaseUser;
 import ch.epfl.favo.FakeItemFactory;
 import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.DependencyFactory;
 import ch.epfl.favo.util.FavorFragmentFactory;
-import ch.epfl.favo.view.tabs.addFavor.FavorDetailView;
 
+import static androidx.navigation.Navigation.findNavController;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -29,6 +32,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static ch.epfl.favo.TestConstants.EMAIL;
 import static ch.epfl.favo.TestConstants.NAME;
 import static ch.epfl.favo.TestConstants.PHOTO_URI;
@@ -38,6 +42,7 @@ import static org.hamcrest.core.AllOf.allOf;
 @RunWith(AndroidJUnit4.class)
 public class FavorDetailViewTest {
   private Favor fakeFavor;
+  private MockDatabaseWrapper mockDatabaseWrapper = new MockDatabaseWrapper<Favor>();
 
   @Rule
   public final ActivityTestRule<MainActivity> mainActivityTestRule =
@@ -46,6 +51,7 @@ public class FavorDetailViewTest {
         protected void beforeActivityLaunched() {
           DependencyFactory.setCurrentFirebaseUser(
               new FakeFirebaseUser(NAME, EMAIL, PHOTO_URI, PROVIDER));
+          DependencyFactory.setCurrentCollectionWrapper(mockDatabaseWrapper);
         }
       };
 
@@ -54,48 +60,67 @@ public class FavorDetailViewTest {
       GrantPermissionRule.grant(android.Manifest.permission.ACCESS_FINE_LOCATION);
 
   @Before
-  public void setUP() {
-    Location mockLocation = createLocation(37, -122, 3.0f);
+  public void setUp() {
     fakeFavor = FakeItemFactory.getFavor();
-  }
-
-  Location createLocation(double lat, double lng, float accuracy) {
-    // Create a new Location
-    Location newLocation = new Location("flp");
-    newLocation.setLatitude(lat);
-    newLocation.setLongitude(lng);
-    newLocation.setAccuracy(accuracy);
-    return newLocation;
+    UserUtil.currentUserId = "USER";
+    NavController navController =
+        findNavController(mainActivityTestRule.getActivity(), R.id.nav_host_fragment);
+    Bundle bundle = new Bundle();
+    bundle.putParcelable(FavorFragmentFactory.FAVOR_ARGS, fakeFavor);
+    navController.navigate(R.id.action_global_favorDetailView, bundle);
   }
 
   @After
   public void tearDown() {
     DependencyFactory.setCurrentFirebaseUser(null);
+    DependencyFactory.setCurrentCollectionWrapper(null);
   }
 
   @Test
   public void favorDetailViewIsLaunched() {
-    FavorDetailView fragment =
-        (FavorDetailView) FavorFragmentFactory.instantiate(fakeFavor, new FavorDetailView());
-
-    FragmentTransaction transaction =
-        mainActivityTestRule.getActivity().getSupportFragmentManager().beginTransaction();
-    transaction.replace(R.id.nav_host_fragment, fragment);
-    transaction.addToBackStack(null);
-    transaction.commit();
-
     // check that detailed view is indeed opened
     onView(
             allOf(
                 withId(R.id.fragment_favor_accept_view),
                 withParent(withId(R.id.nav_host_fragment))))
         .check(matches(isDisplayed()));
+  }
 
-    // Check clicking on the button
-    onView(withId(R.id.accept_button)).check(matches(isDisplayed())).perform(click());
-
+  @Test
+  public void testAcceptButtonShowsSnackBarAndUpdatesDisplay() {
+    CompletableFuture successfulResult = new CompletableFuture();
+    successfulResult.complete(null);
+    mockDatabaseWrapper.setMockDocument(fakeFavor); // set favor in db
+    mockDatabaseWrapper.setMockResult(successfulResult);
+    onView(withId(R.id.accept_button)).perform(click());
+    getInstrumentation().waitForIdleSync();
     // check snackbar shows
     onView(withId(com.google.android.material.R.id.snackbar_text))
         .check(matches(withText(R.string.favor_respond_success_msg)));
+    onView(withId(R.id.status_text_accept_view))
+        .check(matches(withText(Favor.Status.ACCEPTED.getPrettyString())));
+  }
+
+  @Test
+  public void testAcceptButtonShowsFailSnackBar() {
+    CompletableFuture failedResult = new CompletableFuture();
+    failedResult.completeExceptionally(new RuntimeException());
+    mockDatabaseWrapper.setMockResult(failedResult);
+    onView(withId(R.id.accept_button)).perform(click());
+    getInstrumentation().waitForIdleSync();
+    // check snackbar shows
+    onView(withId(com.google.android.material.R.id.snackbar_text))
+        .check(matches(withText("Failed to update")));
+  }
+  @Test
+  public void testFavorFailsToBeAcceptedIfPreviouslyAccepted(){
+    fakeFavor.setStatusId(Favor.Status.ACCEPTED);
+    mockDatabaseWrapper.setMockDocument(fakeFavor);
+    onView(withId(R.id.accept_button)).perform(click());
+    getInstrumentation().waitForIdleSync();
+    // check snackbar shows
+    onView(withId(com.google.android.material.R.id.snackbar_text))
+            .check(matches(withText("Failed to update")));
+
   }
 }

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorPageTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorPageTest.java
@@ -8,6 +8,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 
 import ch.epfl.favo.FakeFirebaseUser;
 import ch.epfl.favo.FakeItemFactory;
@@ -39,6 +40,7 @@ import static org.hamcrest.core.AllOf.allOf;
 
 @RunWith(AndroidJUnit4.class)
 public class FavorPageTest {
+  private MockDatabaseWrapper mockDatabaseWrapper = new MockDatabaseWrapper();
   @Rule
   public final ActivityTestRule<MainActivity> mainActivityTestRule =
       new ActivityTestRule<MainActivity>(MainActivity.class) {
@@ -48,6 +50,8 @@ public class FavorPageTest {
               new FakeFirebaseUser(NAME, EMAIL, PHOTO_URI, PROVIDER));
           DependencyFactory.setCurrentGpsTracker(new MockGpsTracker());
           DependencyFactory.setCurrentCollectionWrapper(new MockDatabaseWrapper());
+          mockDatabaseWrapper.setMockDocument(FakeItemFactory.getFavor());
+          mockDatabaseWrapper.setThrowError(false);
         }
       };
 

--- a/app/src/androidTest/java/ch/epfl/favo/view/FavorPageTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/FavorPageTest.java
@@ -160,7 +160,7 @@ public class FavorPageTest {
     // check favor is displayed in active favor list view
     onView(withText(favor.getTitle())).check(matches(isDisplayed()));
   }
-  
+
 
   @Test
   public void testFavorCancelUpdatesActiveAndArchivedListView() {

--- a/app/src/main/java/ch/epfl/favo/MainActivity.java
+++ b/app/src/main/java/ch/epfl/favo/MainActivity.java
@@ -1,5 +1,6 @@
 package ch.epfl.favo;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Rect;
 import android.os.Build;
@@ -39,6 +40,7 @@ import static ch.epfl.favo.R.id.drawer_layout;
  * This view will control all the fragments that are created. Contains a navigation drawer on the
  * left. Contains a bottom navigation for top-level activities.
  */
+@SuppressLint("NewApi")
 public class MainActivity extends AppCompatActivity
     implements NavigationView.OnNavigationItemSelectedListener, ViewController {
   // Bottom tabs
@@ -79,7 +81,6 @@ public class MainActivity extends AppCompatActivity
   //    archivedFavorArrayList.add(favor);
   //  }
 
-  @RequiresApi(api = Build.VERSION_CODES.M)
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     setTheme(R.style.AppTheme);

--- a/app/src/main/java/ch/epfl/favo/MainActivity.java
+++ b/app/src/main/java/ch/epfl/favo/MainActivity.java
@@ -216,10 +216,6 @@ public class MainActivity extends AppCompatActivity
     switch (itemId) {
       case R.id.nav_home:
         navController.popBackStack(R.id.nav_map, false);
-        // navController.navigate(R.id.action_global_nav_map);
-        // getSupportFragmentManager().popBackStackImmediate();
-        // getSupportFragmentManager().popBackStackImmediate();
-        // getSupportFragmentManager().popBackStackImmediate();
         break;
       case R.id.nav_share:
         startShareIntent();
@@ -308,7 +304,6 @@ public class MainActivity extends AppCompatActivity
     if (extras != null) {
       String favor_id = extras.getString("FavorId");
       CompletableFuture<Favor> favorFuture = FavorUtil.getSingleInstance().retrieveFavor(favor_id);
-
       favorFuture.thenAccept(
           favor -> {
             otherActiveFavorsAround.put(favor.getId(), favor);

--- a/app/src/main/java/ch/epfl/favo/common/CollectionWrapper.java
+++ b/app/src/main/java/ch/epfl/favo/common/CollectionWrapper.java
@@ -23,8 +23,8 @@ public class CollectionWrapper<T extends Document> implements DatabaseUpdater<T>
     DatabaseWrapper.removeDocument(key, collection);
   }
 
-  public void updateDocument(String key, Map<String, Object> updates) {
-    DatabaseWrapper.updateDocument(key, updates, collection);
+  public CompletableFuture updateDocument(String key, Map<String, Object> updates) {
+    return DatabaseWrapper.updateDocument(key, updates, collection);
   }
 
   @Override

--- a/app/src/main/java/ch/epfl/favo/common/DatabaseUpdater.java
+++ b/app/src/main/java/ch/epfl/favo/common/DatabaseUpdater.java
@@ -7,7 +7,7 @@ public interface DatabaseUpdater<T> {
 
   void addDocument(T document) throws RuntimeException;
 
-  void updateDocument(String key, Map<String, Object> updates);
+  CompletableFuture updateDocument(String key, Map<String, Object> updates);
 
   void removeDocument(String key);
 

--- a/app/src/main/java/ch/epfl/favo/common/DatabaseWrapper.java
+++ b/app/src/main/java/ch/epfl/favo/common/DatabaseWrapper.java
@@ -65,8 +65,9 @@ public class DatabaseWrapper {
     getCollectionReference(collection).document(key).delete();
   }
 
-  static void updateDocument(String key, Map<String, Object> updates, String collection) {
-    getCollectionReference(collection).document(key).update(updates);
+  static CompletableFuture updateDocument(String key, Map<String, Object> updates, String collection) {
+    Task update = getCollectionReference(collection).document(key).update(updates);
+    return new TaskToFutureAdapter<>(update).getInstance();
   }
 
   static <T extends Document> CompletableFuture<T> getDocument(

--- a/app/src/main/java/ch/epfl/favo/common/FavoLocation.java
+++ b/app/src/main/java/ch/epfl/favo/common/FavoLocation.java
@@ -15,4 +15,20 @@ public class FavoLocation extends Location {
     super(l);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    /* Check if o is an instance of Complex or not
+    "null instanceof [type]" also returns false */
+    if (!(o instanceof FavoLocation)) {
+      return false;
+    }
+    FavoLocation other = (FavoLocation) o;
+
+    return this.getLongitude() == other.getLongitude()
+            && this.getLatitude() == other.getLatitude();
+  }
 }

--- a/app/src/main/java/ch/epfl/favo/common/FavoLocation.java
+++ b/app/src/main/java/ch/epfl/favo/common/FavoLocation.java
@@ -14,4 +14,5 @@ public class FavoLocation extends Location {
   public FavoLocation(Location l) {
     super(l);
   }
+
 }

--- a/app/src/main/java/ch/epfl/favo/common/FavorAlreadyAcceptedException.java
+++ b/app/src/main/java/ch/epfl/favo/common/FavorAlreadyAcceptedException.java
@@ -1,0 +1,5 @@
+package ch.epfl.favo.common;
+
+public class FavorAlreadyAcceptedException extends RuntimeException{
+  public FavorAlreadyAcceptedException(String s){super(s);}
+}

--- a/app/src/main/java/ch/epfl/favo/common/FavorAlreadyAcceptedException.java
+++ b/app/src/main/java/ch/epfl/favo/common/FavorAlreadyAcceptedException.java
@@ -1,5 +1,0 @@
-package ch.epfl.favo.common;
-
-public class FavorAlreadyAcceptedException extends RuntimeException{
-  public FavorAlreadyAcceptedException(String s){super(s);}
-}

--- a/app/src/main/java/ch/epfl/favo/common/FavorNoLongerAvailableException.java
+++ b/app/src/main/java/ch/epfl/favo/common/FavorNoLongerAvailableException.java
@@ -1,0 +1,5 @@
+package ch.epfl.favo.common;
+
+public class FavorNoLongerAvailableException extends RuntimeException{
+  public FavorNoLongerAvailableException(String s){super(s);}
+}

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -78,7 +78,6 @@ public class Favor implements Parcelable, Document {
       Status statusId) {
 
     this.id = DatabaseWrapper.generateRandomId();
-    ;
     this.title = title;
     this.description = description;
     this.requesterId = requesterId;
@@ -170,16 +169,13 @@ public class Favor implements Parcelable, Document {
   public String getAccepterId() {
     return accepterId;
   }
-  public void setAccepterId(String id){
+
+  public void setAccepterId(String id) {
     this.accepterId = id;
   }
 
   public Date getPostedTime() {
     return postedTime;
-  }
-
-  void setAccepterID(String accepterID) {
-    this.accepterId = accepterID;
   }
 
   /**
@@ -220,13 +216,12 @@ public class Favor implements Parcelable, Document {
   }
 
   public void updateToOther(Favor other) {
-    // we take all the values except for the ID
+    // we take all the values except for the id, acceptor and requester id
 
     this.title = other.getTitle();
     this.description = other.getDescription();
     this.location = other.getLocation();
     this.postedTime = other.getPostedTime();
-    this.requesterId = other.getRequesterId();
     this.statusId = other.getStatusId();
   }
   // Overriding equals() to compare two Complex objects
@@ -238,8 +233,8 @@ public class Favor implements Parcelable, Document {
       return true;
     }
 
-        /* Check if o is an instance of Complex or not
-          "null instanceof [type]" also returns false */
+    /* Check if o is an instance of Complex or not
+    "null instanceof [type]" also returns false */
     if (!(o instanceof Favor)) {
       return false;
     }
@@ -248,9 +243,11 @@ public class Favor implements Parcelable, Document {
     Favor other = (Favor) o;
 
     // Compare the data members and return accordingly
+
     return this.title.equals(other.title)
-            && this.description.equals(other.description)
-            && this.statusId.equals(other.getStatusId())
-            && this.location.equals(other.getLocation());
+        && this.description.equals(other.description)
+        && this.statusId.equals(other.getStatusId())
+        && (this.location.getLatitude() == other.location.getLatitude())
+        && (this.location.getLongitude() == other.location.getLongitude());
   }
 }

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -17,24 +17,12 @@ import ch.epfl.favo.common.FavoLocation;
  */
 public class Favor implements Parcelable, Document {
   public enum Status {
-    REQUESTED("Requested"),
-    EDIT("Edit mode"), // temporary state used for logic in the request view
-    ACCEPTED_BY_OTHER("Accepted by other"), // temporary state used for logic in detail view
-    ACCEPTED("Accepted"),
-    EXPIRED("Expired"),
-    CANCELLED_REQUESTER("Cancelled by requester"),
-    CANCELLED_ACCEPTER("Cancelled by accepter"),
-    SUCCESSFULLY_COMPLETED("Completed succesfully");
-
-    private String customDisplay;
-
-    Status(String custom) {
-      this.customDisplay = custom;
-    }
-
-    public String getPrettyString() {
-      return customDisplay;
-    }
+    REQUESTED,
+    ACCEPTED,
+    EXPIRED,
+    CANCELLED_REQUESTER,
+    CANCELLED_ACCEPTER,
+    SUCCESSFULLY_COMPLETED
   }
 
   // String constants for Map conversion

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -241,13 +241,16 @@ public class Favor implements Parcelable, Document {
 
     // typecast o to Complex so that we can compare data members
     Favor other = (Favor) o;
+    boolean contentIsEqual =
+        this.title.equals(other.title)
+            && this.description.equals(other.description)
+            && this.statusId.equals(other.getStatusId());
+
+    boolean locationIsEqual =
+        this.location.getLatitude() == other.location.getLatitude()
+            && this.location.getLongitude() == other.location.getLongitude();
 
     // Compare the data members and return accordingly
-
-    return this.title.equals(other.title)
-        && this.description.equals(other.description)
-        && this.statusId.equals(other.getStatusId())
-        && (this.location.getLatitude() == other.location.getLatitude())
-        && (this.location.getLongitude() == other.location.getLongitude());
+    return contentIsEqual && locationIsEqual;
   }
 }

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -20,6 +20,7 @@ public class Favor implements Parcelable, Document {
   public enum Status {
     REQUESTED("Requested"),
     EDIT("Edit mode"), // temporary state used for logic in the request view
+    ACCEPTED_BY_OTHER("Accepted by other"),//temporary state used for logic in detail view
     ACCEPTED("Accepted"),
     EXPIRED("Expired"),
     CANCELLED_REQUESTER("Cancelled by requester"),

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -225,24 +225,7 @@ public class Favor implements Parcelable, Document {
     this.statusId = other.getStatusId();
   }
   // Overriding equals() to compare two Complex objects
-  @Override
-  public boolean equals(Object o) {
-
-    // If the object is compared with itself then return true
-    if (o == this) {
-      return true;
-    }
-
-    /* Check if o is an instance of Complex or not
-    "null instanceof [type]" also returns false */
-    if (!(o instanceof Favor)) {
-      return false;
-    }
-
-    // typecast o to Complex so that we can compare data members
-    Favor other = (Favor) o;
-
-    // Compare the data members and return accordingly
+  public boolean contentEquals(Favor other) {
     return this.title.equals(other.title)
         && this.description.equals(other.description)
         && this.statusId.equals(other.getStatusId())

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import ch.epfl.favo.common.DatabaseWrapper;
 import ch.epfl.favo.common.Document;
 import ch.epfl.favo.common.FavoLocation;
-
 /**
  * Class contains all the information relevant to a single favor. Relevant info includes tile,
  * description, requester, accepter, location and status
@@ -20,7 +19,7 @@ public class Favor implements Parcelable, Document {
   public enum Status {
     REQUESTED("Requested"),
     EDIT("Edit mode"), // temporary state used for logic in the request view
-    ACCEPTED_BY_OTHER("Accepted by other"),//temporary state used for logic in detail view
+    ACCEPTED_BY_OTHER("Accepted by other"), // temporary state used for logic in detail view
     ACCEPTED("Accepted"),
     EXPIRED("Expired"),
     CANCELLED_REQUESTER("Cancelled by requester"),
@@ -167,8 +166,11 @@ public class Favor implements Parcelable, Document {
     return requesterId;
   }
 
-  public String getAccepterID() {
+  public String getAccepterId() {
     return accepterId;
+  }
+  public void setAccepterId(String id){
+    this.accepterId = id;
   }
 
   public Date getPostedTime() {
@@ -225,5 +227,29 @@ public class Favor implements Parcelable, Document {
     this.postedTime = other.getPostedTime();
     this.requesterId = other.getRequesterId();
     this.statusId = other.getStatusId();
+  }
+  // Overriding equals() to compare two Complex objects
+  @Override
+  public boolean equals(Object o) {
+
+    // If the object is compared with itself then return true
+    if (o == this) {
+      return true;
+    }
+
+        /* Check if o is an instance of Complex or not
+          "null instanceof [type]" also returns false */
+    if (!(o instanceof Favor)) {
+      return false;
+    }
+
+    // typecast o to Complex so that we can compare data members
+    Favor other = (Favor) o;
+
+    // Compare the data members and return accordingly
+    return this.title.equals(other.title)
+            && this.description.equals(other.description)
+            && this.statusId.equals(other.getStatusId())
+            && this.location.equals(other.getLocation());
   }
 }

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -241,16 +241,11 @@ public class Favor implements Parcelable, Document {
 
     // typecast o to Complex so that we can compare data members
     Favor other = (Favor) o;
-    boolean contentIsEqual =
-        this.title.equals(other.title)
-            && this.description.equals(other.description)
-            && this.statusId.equals(other.getStatusId());
-
-    boolean locationIsEqual =
-        this.location.getLatitude() == other.location.getLatitude()
-            && this.location.getLongitude() == other.location.getLongitude();
 
     // Compare the data members and return accordingly
-    return contentIsEqual && locationIsEqual;
+    return this.title.equals(other.title)
+        && this.description.equals(other.description)
+        && this.statusId.equals(other.getStatusId())
+        && this.location.equals(other.location);
   }
 }

--- a/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
+++ b/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
@@ -10,7 +10,6 @@ import androidx.annotation.RequiresApi;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import ch.epfl.favo.common.DatabaseUpdater;
@@ -56,32 +55,19 @@ public class FavorUtil {
 
   @RequiresApi(api = Build.VERSION_CODES.N)
   public CompletableFuture updateFavor(Favor favor) {
-    CompletableFuture completableFuture = new CompletableFuture();
-    try {
-      completableFuture = collection.updateDocument(favor.getId(), favor.toMap());
-    } catch (Exception e) {
-      Log.d(TAG, Objects.requireNonNull(e.getMessage()));
-    }
-    return completableFuture;
+    return collection.updateDocument(favor.getId(), favor.toMap());
   }
 
   @RequiresApi(api = Build.VERSION_CODES.N)
   public CompletableFuture updateFavorStatus(String favorId, Favor.Status newStatus) {
-    CompletableFuture updateFuture = new CompletableFuture();
-    try {
-      updateFuture =
-          collection.updateDocument(
-              favorId,
-              new HashMap<String, String>() {
-                {
-                  put(Favor.ACCEPTER_ID, UserUtil.currentUserId);
-                  put(Favor.STATUS_ID, newStatus.toString());
-                }
-              });
-    } catch (Exception e) {
-      Log.d(TAG, Objects.requireNonNull(e.getMessage()));
-    }
-    return updateFuture;
+    Map updates =
+        new HashMap<String, String>() {
+          {
+            put(Favor.ACCEPTER_ID, UserUtil.currentUserId);
+            put(Favor.STATUS_ID, newStatus.toString());
+          }
+        };
+    return updateFavor(favorId, updates);
   }
 
   /**
@@ -89,24 +75,15 @@ public class FavorUtil {
    * @return CompletableFuture<Favor>
    */
   public CompletableFuture<Favor> retrieveFavor(String favorId) {
-    try {
-      return collection.getDocument(favorId);
-    } catch (RuntimeException e) {
-      Log.d(TAG, "unable to retrieve document from db.");
-    }
-    return new CompletableFuture<>();
+    return collection.getDocument(favorId);
   }
 
   /**
    * @param favorId the id of the favor to retrieve from DB.
    * @return CompletableFuture<Favor>
    */
-  public void updateFavor(String favorId, Map<String, Object> updates) {
-    try {
-      collection.updateDocument(favorId, updates);
-    } catch (RuntimeException e) {
-      Log.d(TAG, "unable to retrieve document from db.");
-    }
+  public CompletableFuture updateFavor(String favorId, Map<String, Object> updates) {
+    return collection.updateDocument(favorId, updates);
   }
 
   /**

--- a/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
+++ b/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import ch.epfl.favo.common.DatabaseUpdater;
-import ch.epfl.favo.common.FavorAlreadyAcceptedException;
+import ch.epfl.favo.common.FavorNoLongerAvailableException;
 import ch.epfl.favo.common.NotImplementedException;
 import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.DependencyFactory;
@@ -71,7 +71,7 @@ public class FavorUtil {
         .thenAccept(
             favor -> {
               if (favor.getStatusId() != Favor.Status.REQUESTED) {
-                throw new FavorAlreadyAcceptedException("Favor has been accepted by another user.");
+                throw new FavorNoLongerAvailableException("Favor is no longer available");
               } else {
                 collection.updateDocument(
                     favorId,

--- a/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
+++ b/app/src/main/java/ch/epfl/favo/favor/FavorUtil.java
@@ -65,27 +65,6 @@ public class FavorUtil {
   }
 
   @RequiresApi(api = Build.VERSION_CODES.N)
-  public CompletableFuture acceptFavor(String favorId) {
-    CompletableFuture<Favor> getCurrentFavorTask = retrieveFavor(favorId);
-    return getCurrentFavorTask
-        .thenAccept(
-            favor -> {
-              if (favor.getStatusId() != Favor.Status.REQUESTED) {
-                throw new FavorNoLongerAvailableException("Favor is no longer available");
-              } else {
-                collection.updateDocument(
-                    favorId,
-                    new HashMap<String, String>() {
-                      {
-                        put(Favor.ACCEPTER_ID, UserUtil.currentUserId);
-                        put(Favor.STATUS_ID, Favor.Status.ACCEPTED.getPrettyString());
-                      }
-                    });
-              }
-            });
-  }
-
-  @RequiresApi(api = Build.VERSION_CODES.N)
   public CompletableFuture updateFavorStatus(String favorId, Favor.Status newStatus) {
     CompletableFuture updateFuture = new CompletableFuture();
     try {

--- a/app/src/main/java/ch/epfl/favo/user/UserUtil.java
+++ b/app/src/main/java/ch/epfl/favo/user/UserUtil.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
+import ch.epfl.favo.common.CollectionWrapper;
 import ch.epfl.favo.common.DatabaseUpdater;
 import ch.epfl.favo.common.NotImplementedException;
 import ch.epfl.favo.util.DependencyFactory;
@@ -113,5 +114,8 @@ public class UserUtil {
               notifMap.put("notificationId", token);
               collection.updateDocument(user.getId(), notifMap);
             });
+  }
+  public void setCollectionWrapper(CollectionWrapper collectionWrapper){
+    this.collection = collectionWrapper;
   }
 }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/FavorDetailView.java
@@ -1,7 +1,7 @@
 package ch.epfl.favo.view.tabs;
 
+import android.annotation.SuppressLint;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,7 +9,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
-import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -27,6 +26,7 @@ import ch.epfl.favo.util.CommonTools;
 import ch.epfl.favo.util.FavorFragmentFactory;
 import ch.epfl.favo.view.ViewController;
 
+@SuppressLint("NewApi")
 public class FavorDetailView extends Fragment {
   private Favor currentFavor;
   private FloatingActionButton locationAccessBtn;
@@ -38,7 +38,6 @@ public class FavorDetailView extends Fragment {
     // create favor detail from a favor
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -51,14 +50,12 @@ public class FavorDetailView extends Fragment {
 
     if (currentFavor == null) {
       currentFavor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
-
     }
     displayFromFavor(rootView, currentFavor);
 
     return rootView;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private void setupButtons(View rootView) {
     acceptAndCancelFavorBtn = rootView.findViewById(R.id.accept_button);
     locationAccessBtn = rootView.findViewById(R.id.location_accept_view_btn);
@@ -75,7 +72,6 @@ public class FavorDetailView extends Fragment {
         });
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private void cancelFavor() {
     CompletableFuture completableFuture =
         FavorUtil.getSingleInstance()
@@ -95,7 +91,6 @@ public class FavorDetailView extends Fragment {
     };
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private CompletableFuture<Favor> retrieveFavorWrapper() {
     CompletableFuture<Favor> futureFavor =
         FavorUtil.getSingleInstance().retrieveFavor(currentFavor.getId());
@@ -109,7 +104,6 @@ public class FavorDetailView extends Fragment {
         });
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private void acceptFavor() {
     CompletableFuture<Favor> favorFuture = retrieveFavorWrapper();
     favorFuture // get updated favor from db
@@ -131,7 +125,6 @@ public class FavorDetailView extends Fragment {
     favorFuture.exceptionally(favorFailedToBeAcceptedConsumer());
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private Function favorFailedToBeAcceptedConsumer() {
     return e -> {
       // if already accepted then change the status display and disable all the buttons

--- a/app/src/main/java/ch/epfl/favo/view/tabs/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/FavorDetailView.java
@@ -1,4 +1,4 @@
-package ch.epfl.favo.view.tabs.addFavor;
+package ch.epfl.favo.view.tabs;
 
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -115,7 +115,7 @@ public class FavorDetailView extends Fragment {
     favorFuture // get updated favor from db
         .thenAccept(
         favor -> {
-          if (!favor.equals(currentFavor)) { // if favor changed, update the view
+          if (!favor.contentEquals(currentFavor)) { // if favor changed, update the view
             currentFavor.updateToOther(favor);
             CommonTools.showSnackbar(getView(), getString(R.string.favor_remotely_changed_msg));
             displayFromFavor(getView(), favor);

--- a/app/src/main/java/ch/epfl/favo/view/tabs/FavorPage.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/FavorPage.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.user.UserUtil;
 import ch.epfl.favo.util.CommonTools;
 import ch.epfl.favo.view.ViewController;
 import ch.epfl.favo.view.tabs.favorList.FavorAdapter;
@@ -167,12 +168,14 @@ public class FavorPage extends Fragment implements View.OnClickListener {
           Favor favor = (Favor) parent.getItemAtPosition(position);
           Bundle favorBundle = new Bundle();
           favorBundle.putParcelable("FAVOR_ARGS", favor);
-          Navigation.findNavController(getView())
-              .navigate(R.id.action_nav_favorlist_to_favorRequestView, favorBundle);
-          // CommonTools.replaceFragment(
-          //    R.id.nav_host_fragment,
-          //    getParentFragmentManager(),
-          //        FavorFragmentFactory.instantiate(favor,new FavorRequestView()));
+          // if favor was requested, open request view
+          if (favor.getRequesterId().equals(UserUtil.currentUserId)) {
+            Navigation.findNavController(getView())
+                .navigate(R.id.action_nav_favorlist_to_favorRequestView, favorBundle);
+          } else { // if favor was accepted, open accept view
+            Navigation.findNavController(getView())
+                .navigate(R.id.action_nav_favorlist_to_favorDetailView, favorBundle);
+          }
         });
   }
 

--- a/app/src/main/java/ch/epfl/favo/view/tabs/FavorPage.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/FavorPage.java
@@ -2,7 +2,6 @@ package ch.epfl.favo.view.tabs;
 
 import android.annotation.SuppressLint;
 import android.graphics.Point;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Display;
 import android.view.LayoutInflater;
@@ -14,7 +13,6 @@ import android.widget.SearchView;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.Navigation;
 
@@ -38,6 +36,7 @@ import static ch.epfl.favo.util.CommonTools.hideKeyboardFrom;
  * that will expand to give more information about them. This object is a simple {@link Fragment}
  * subclass.
  */
+@SuppressLint("NewApi")
 public class FavorPage extends Fragment implements View.OnClickListener {
 
   private Map<String, Favor> activeFavors;
@@ -68,7 +67,6 @@ public class FavorPage extends Fragment implements View.OnClickListener {
     screenWidth = size.x;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.M)
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
@@ -90,6 +90,7 @@ public class FavorDetailView extends Fragment {
       // update UI
       currentFavor.setStatusId(Favor.Status.CANCELLED_ACCEPTER);
       ((MainActivity) getActivity()).activeFavors.remove(currentFavor.getId());
+      ((MainActivity) getActivity()).archivedFavors.remove(currentFavor.getId());
       updateStatusDisplayFromFavorStatus();
     };
   }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
@@ -1,5 +1,6 @@
 package ch.epfl.favo.view.tabs.addFavor;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -7,21 +8,37 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.annotation.RequiresApi;
 import androidx.fragment.app.Fragment;
 
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
+import ch.epfl.favo.common.FavorAlreadyAcceptedException;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorUtil;
 import ch.epfl.favo.util.CommonTools;
 import ch.epfl.favo.util.FavorFragmentFactory;
 import ch.epfl.favo.view.ViewController;
 
 public class FavorDetailView extends Fragment {
   private Favor favor;
+  private FloatingActionButton locationAccessBtn;
+  private Button confirmFavorBtn;
+  private Button chatBtn;
+  private TextView statusText;
 
   public FavorDetailView() {
     // create favor detail from a favor
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.N)
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -29,16 +46,8 @@ public class FavorDetailView extends Fragment {
     setupView();
     // inflate view
     View rootView = inflater.inflate(R.layout.fragment_favor_accept_view, container, false);
-    Button confirmFavorBtn = rootView.findViewById(R.id.accept_button);
-
-    // Show snackbar when favor has been confirmed
-    confirmFavorBtn.setOnClickListener(
-        new View.OnClickListener() {
-          @Override
-          public void onClick(View v) {
-            CommonTools.showSnackbar(getView(), getString(R.string.favor_respond_success_msg));
-          }
-        });
+    setupButtons(rootView);
+    statusText = rootView.findViewById(R.id.status_text_accept_view);
 
     if (favor == null) {
       favor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
@@ -48,22 +57,90 @@ public class FavorDetailView extends Fragment {
     return rootView;
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  private void setupButtons(View rootView) {
+    confirmFavorBtn = rootView.findViewById(R.id.accept_button);
+    locationAccessBtn = rootView.findViewById(R.id.location_accept_view_btn);
+    chatBtn = rootView.findViewById(R.id.chat_button_accept_view);
+
+    // Show snackbar when favor has been confirmed
+    confirmFavorBtn.setOnClickListener(v -> acceptFavor());
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  @NotNull
+  private void acceptFavor() {
+    CompletableFuture acceptFavorFuture = FavorUtil.getSingleInstance().acceptFavor(favor.getId());
+    acceptFavorFuture.thenAccept(
+        o -> {
+          CommonTools.showSnackbar(getView(), getString(R.string.favor_respond_success_msg));
+          ((MainActivity) requireActivity()).activeFavors.put(favor.getId(), favor);
+          favor.setStatusId(Favor.Status.ACCEPTED);
+          updateStatusDisplayFromFavorStatus();
+        });
+    acceptFavorFuture.exceptionally(
+        e -> {
+          if (((CompletionException) e).getCause().equals(FavorAlreadyAcceptedException.class)) {
+            CommonTools.showSnackbar(getView(), "Favor has already been accepted :(");
+            favor.setStatusId(Favor.Status.ACCEPTED_BY_OTHER);
+            updateStatusDisplayFromFavorStatus();
+          }
+          CommonTools.showSnackbar(getView(), "Failed to update");
+          return null;
+        });
+  }
+
   private void displayFromFavor(View rootView, Favor favor) {
-    String greetingStr = "favor of " + favor.getRequesterId();
-    String locationStr =
-        "latitude: "
-            + String.format("%.4f", favor.getLocation().getLatitude())
-            + " longitude: "
-            + String.format("%.4f", favor.getLocation().getLongitude());
+    //    String greetingStr = "favor of " + favor.getRequesterId();
+    //    String locationStr =
+    //        "latitude: "
+    //            + String.format("%.4f", favor.getLocation().getLatitude())
+    //            + " longitude: "
+    //            + String.format("%.4f", favor.getLocation().getLongitude());
     String timeStr = CommonTools.convertTime(favor.getLocation().getTime());
     String titleStr = favor.getTitle();
     String descriptionStr = favor.getDescription();
+    // update status string
+    updateStatusDisplayFromFavorStatus();
 
-    setupTextView(rootView, R.id.favor_greeting_text_accept, greetingStr);
-    setupTextView(rootView, R.id.location_accept_view, locationStr);
     setupTextView(rootView, R.id.datetime_accept_view, timeStr);
     setupTextView(rootView, R.id.title_accept_view, titleStr);
     setupTextView(rootView, R.id.details_accept_view, descriptionStr);
+  }
+
+  private void updateStatusDisplayFromFavorStatus() {
+    Favor.Status newStatus = favor.getStatusId();
+    statusText.setText(newStatus.getPrettyString());
+    switch (newStatus) {
+      case SUCCESSFULLY_COMPLETED:
+        {
+        }
+      case ACCEPTED:
+        {
+          enableButtons(false, true);
+          statusText.setBackgroundColor(getResources().getColor(R.color.accepted_status_bg));
+          break;
+        }
+
+      case REQUESTED:
+        {
+          enableButtons(true, true);
+          statusText.setBackgroundColor(getResources().getColor(R.color.requested_status_bg));
+          break;
+        }
+      case ACCEPTED_BY_OTHER:
+        {
+          enableButtons(false, false);
+        }
+      default: // includes accepted by other
+        enableButtons(false, false);
+        statusText.setBackgroundColor(getResources().getColor(R.color.cancelled_status_bg));
+    }
+  }
+
+  private void enableButtons(boolean acceptButton, boolean chatButton) {
+    confirmFavorBtn.setEnabled(acceptButton);
+    chatBtn.setEnabled(chatButton);
   }
 
   private void setupTextView(View rootView, int id, String text) {

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
@@ -1,4 +1,4 @@
-package ch.epfl.favo.view.tabs;
+package ch.epfl.favo.view.tabs.addFavor;
 
 import android.annotation.SuppressLint;
 import android.graphics.drawable.Drawable;
@@ -28,6 +28,8 @@ import ch.epfl.favo.view.ViewController;
 
 @SuppressLint("NewApi")
 public class FavorDetailView extends Fragment {
+
+  private FavorViewStatus viewStatus;
   private Favor currentFavor;
   private FloatingActionButton locationAccessBtn;
   private Button acceptAndCancelFavorBtn;
@@ -83,29 +85,33 @@ public class FavorDetailView extends Fragment {
   private Consumer successfullyCancelledConsumer() {
     return o -> {
       CommonTools.showSnackbar(getView(), getString(R.string.favor_cancel_success_msg));
-      // update UI
-      currentFavor.setStatusId(Favor.Status.CANCELLED_ACCEPTER);
+
       ((MainActivity) getActivity()).activeFavors.remove(currentFavor.getId());
       ((MainActivity) getActivity()).archivedFavors.remove(currentFavor.getId());
-      updateStatusDisplayFromFavorStatus();
+      // update UI
+      currentFavor.setStatusId(Favor.Status.CANCELLED_ACCEPTER);
+      viewStatus = convertFavorStatusToViewStatus(currentFavor);
+      updateDisplayFromViewStatus();
     };
   }
 
-  private CompletableFuture<Favor> retrieveFavorWrapper() {
-    CompletableFuture<Favor> futureFavor =
-        FavorUtil.getSingleInstance().retrieveFavor(currentFavor.getId());
-    return futureFavor.thenApply(
-        favor -> {
-          if (favor.getStatusId().equals(Favor.Status.ACCEPTED)
-              && (!UserUtil.currentUserId.equals(favor.getAccepterId()))) {
-            favor.setStatusId(Favor.Status.ACCEPTED_BY_OTHER);
-          }
-          return favor;
-        });
+  private FavorViewStatus convertFavorStatusToViewStatus(Favor favor) {
+    // Equivalent mapping except for the accepted case. Here we check if the
+    // accepter Id matches the current user
+    Favor.Status favorStatus = favor.getStatusId();
+    FavorViewStatus resultStatus;
+    if (favorStatus.equals(Favor.Status.ACCEPTED)
+        && !favor.getRequesterId().equals(UserUtil.currentUserId)) {
+      resultStatus = FavorViewStatus.ACCEPTED_BY_OTHER;
+    } else { // need to ensure that the name is the same as the name in Favor class
+      resultStatus = FavorViewStatus.valueOf(favorStatus.toString());
+    }
+    return resultStatus;
   }
 
   private void acceptFavor() {
-    CompletableFuture<Favor> favorFuture = retrieveFavorWrapper();
+    CompletableFuture<Favor> favorFuture =
+        FavorUtil.getSingleInstance().retrieveFavor(currentFavor.getId());
     favorFuture // get updated favor from db
         .thenAccept(
         favor -> {
@@ -113,7 +119,6 @@ public class FavorDetailView extends Fragment {
             currentFavor.updateToOther(favor);
             CommonTools.showSnackbar(getView(), getString(R.string.favor_remotely_changed_msg));
             displayFromFavor(getView(), favor);
-            updateStatusDisplayFromFavorStatus();
           } else { // update DB with accepted status
             CompletableFuture updateFavorFuture =
                 FavorUtil.getSingleInstance()
@@ -139,7 +144,8 @@ public class FavorDetailView extends Fragment {
 
       ((MainActivity) requireActivity()).activeFavors.put(currentFavor.getId(), currentFavor);
       currentFavor.setStatusId(Favor.Status.ACCEPTED);
-      updateStatusDisplayFromFavorStatus();
+      viewStatus = FavorViewStatus.ACCEPTED;
+      updateDisplayFromViewStatus();
     };
   }
 
@@ -149,18 +155,18 @@ public class FavorDetailView extends Fragment {
     String titleStr = favor.getTitle();
     String descriptionStr = favor.getDescription();
     // update status string
-    updateStatusDisplayFromFavorStatus();
+    viewStatus = convertFavorStatusToViewStatus(favor);
+    updateDisplayFromViewStatus();
 
     setupTextView(rootView, R.id.datetime_accept_view, timeStr);
     setupTextView(rootView, R.id.title_accept_view, titleStr);
     setupTextView(rootView, R.id.details_accept_view, descriptionStr);
   }
 
-  private void updateStatusDisplayFromFavorStatus() {
-    Favor.Status newStatus = currentFavor.getStatusId();
-    statusText.setText(newStatus.getPrettyString());
-    updateButtonDisplay(newStatus);
-    switch (newStatus) {
+  private void updateDisplayFromViewStatus() {
+    statusText.setText(viewStatus.getPrettyString());
+    updateButtonDisplay();
+    switch (viewStatus) {
       case SUCCESSFULLY_COMPLETED:
         {
           enableButtons(false);
@@ -182,15 +188,15 @@ public class FavorDetailView extends Fragment {
     }
   }
 
-  private void updateButtonDisplay(Favor.Status status) {
+  private void updateButtonDisplay() {
     String displayMessage;
     int backgroundColor;
     Drawable img;
-    if (status == Favor.Status.ACCEPTED) {
+    if (viewStatus == FavorViewStatus.ACCEPTED) {
       displayMessage = getString(R.string.cancel_accept_button_display);
       backgroundColor = R.color.fui_transparent;
       img = getResources().getDrawable(R.drawable.ic_cancel_24dp);
-    } else {
+    } else { // includes ACCEPTED_BY_OTHER
       displayMessage = getResources().getString(R.string.accept_favor);
       img = getResources().getDrawable(R.drawable.ic_thumb_up_24dp);
       backgroundColor = android.R.drawable.btn_default;

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorDetailView.java
@@ -51,6 +51,7 @@ public class FavorDetailView extends Fragment {
 
     if (currentFavor == null) {
       currentFavor = getArguments().getParcelable(FavorFragmentFactory.FAVOR_ARGS);
+
     }
     displayFromFavor(rootView, currentFavor);
 
@@ -117,6 +118,7 @@ public class FavorDetailView extends Fragment {
             currentFavor.updateToOther(favor);
             CommonTools.showSnackbar(getView(), getString(R.string.favor_remotely_changed_msg));
             displayFromFavor(getView(), favor);
+            updateStatusDisplayFromFavorStatus();
           } else { // update DB with accepted status
             CompletableFuture updateFavorFuture =
                 FavorUtil.getSingleInstance()
@@ -140,6 +142,7 @@ public class FavorDetailView extends Fragment {
   private Consumer favorAcceptedConsumer() {
     return o -> {
       CommonTools.showSnackbar(getView(), getString(R.string.favor_respond_success_msg));
+
       ((MainActivity) requireActivity()).activeFavors.put(currentFavor.getId(), currentFavor);
       currentFavor.setStatusId(Favor.Status.ACCEPTED);
       updateStatusDisplayFromFavorStatus();

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -266,7 +266,7 @@ public class FavorRequestView extends Fragment {
       default: // cancelled
         {
           mStatusView.setBackgroundColor(getResources().getColor(R.color.cancelled_status_bg));
-          editFavorBtn.setText(R.string.edit_favor);
+          editFavorBtn.setText(R.string.restart_request);
           updateViewFromParameters(view, false, true, false, true, false);
         }
     }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.hardware.Camera;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.method.KeyListener;
 import android.view.LayoutInflater;
@@ -19,7 +18,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
@@ -45,6 +43,7 @@ import ch.epfl.favo.view.ViewController;
 import static android.app.Activity.RESULT_OK;
 import static ch.epfl.favo.util.CommonTools.hideKeyboardFrom;
 
+@SuppressLint("NewApi")
 public class FavorRequestView extends Fragment {
 
   public static final int PICK_IMAGE_REQUEST = 1;
@@ -66,7 +65,6 @@ public class FavorRequestView extends Fragment {
     // Required empty public constructor
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -109,7 +107,6 @@ public class FavorRequestView extends Fragment {
    *
    * @param rootView
    */
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private void setupButtons(View rootView) {
 
     // Button: Request Favor
@@ -167,7 +164,6 @@ public class FavorRequestView extends Fragment {
    * Method is called when request favor button is clicked. It uploads favor request to the database
    * and updates view so that favor is editable.
    */
-  @RequiresApi(api = Build.VERSION_CODES.M)
   private void requestFavor() {
     // update currentFavor
     getFavorFromView(Favor.Status.REQUESTED);
@@ -199,7 +195,6 @@ public class FavorRequestView extends Fragment {
   }
 
   /** When edit button is clicked */
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private void startUpdatingFavor() {
     CompletableFuture<Favor> currentFavorFuture =
         FavorUtil.getSingleInstance().retrieveFavor(currentFavor.getId());
@@ -351,7 +346,6 @@ public class FavorRequestView extends Fragment {
   }
 
   /** Called when camera button is clicked Method calls camera intent. */
-  @RequiresApi(api = Build.VERSION_CODES.M)
   public void takePicture() {
     if (ContextCompat.checkSelfPermission(
             Objects.requireNonNull(getContext()), Manifest.permission.CAMERA)

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -23,8 +23,6 @@ import androidx.fragment.app.Fragment;
 
 import com.google.android.material.snackbar.Snackbar;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -46,8 +44,10 @@ import static ch.epfl.favo.util.CommonTools.hideKeyboardFrom;
 @SuppressLint("NewApi")
 public class FavorRequestView extends Fragment {
 
+
   public static final int PICK_IMAGE_REQUEST = 1;
   public static final int USE_CAMERA_REQUEST = 2;
+  private FavorViewStatus viewStatus;
   private ImageView mImageView;
   private EditText mTitleView;
   private EditText mDescriptionView;
@@ -96,9 +96,11 @@ public class FavorRequestView extends Fragment {
 
   /** When fragment is launched with favor. */
   public void displayFavorInfo(View v) {
+    viewStatus = FavorViewStatus.valueOf(currentFavor.getStatusId().toString());
     mTitleView.setText(currentFavor.getTitle());
     mDescriptionView.setText(currentFavor.getDescription());
-    mStatusView.setText(currentFavor.getStatusId().toString());
+    mStatusView.setText(viewStatus.getPrettyString());
+
     updateViewFromStatus(v);
   }
 
@@ -137,7 +139,7 @@ public class FavorRequestView extends Fragment {
     editFavorBtn.setOnClickListener(
         v -> {
           // if text is currently "Update Request"
-          if (currentFavor.getStatusId() == Favor.Status.EDIT) {
+          if (viewStatus.equals(FavorViewStatus.EDIT)) {
             confirmUpdatedFavor();
           } else { // text is currently "Edit Request"
             startUpdatingFavor();
@@ -166,7 +168,8 @@ public class FavorRequestView extends Fragment {
    */
   private void requestFavor() {
     // update currentFavor
-    getFavorFromView(Favor.Status.REQUESTED);
+    viewStatus = FavorViewStatus.REQUESTED;
+    getFavorFromView(viewStatus);
     // post to DB
     FavorUtil.getSingleInstance().postFavor(currentFavor);
     // Save the favor to local favorList
@@ -203,8 +206,9 @@ public class FavorRequestView extends Fragment {
           if (favor.getStatusId().equals(Favor.Status.ACCEPTED)) {
             CommonTools.showSnackbar(getView(), getString(R.string.fail_edit_favor_request_view));
             currentFavor.setStatusId(favor.getStatusId());
+            viewStatus = FavorViewStatus.valueOf(favor.getStatusId().toString());
           } else {
-            currentFavor.setStatusId(Favor.Status.EDIT);
+            viewStatus = FavorViewStatus.EDIT;
           }
           updateViewFromStatus(getView());
         });
@@ -217,7 +221,8 @@ public class FavorRequestView extends Fragment {
 
   /** Gets called once favor has been updated on view. */
   private void confirmUpdatedFavor() {
-    getFavorFromView(Favor.Status.REQUESTED);
+    viewStatus = FavorViewStatus.REQUESTED;
+    getFavorFromView(viewStatus);
     // update lists
     updateMainActivityLists(true);
     updateViewFromStatus(getView());
@@ -230,15 +235,15 @@ public class FavorRequestView extends Fragment {
   /** Updates favor on DB. Updates maps on main activity hides keyboard shows snackbar */
   private void cancelFavor() {
     currentFavor.setStatusId(Favor.Status.CANCELLED_REQUESTER);
+    viewStatus = FavorViewStatus.CANCELLED_REQUESTER;
     updateMainActivityLists(false);
     updateViewFromStatus(getView());
     // Show confirmation and minimize keyboard
     showSnackbar(getString(R.string.favor_cancel_success_msg));
 
     // DB call to update status
-    Map<String, Object> statusUpdates = new HashMap<>();
-    statusUpdates.put("statusId", Favor.Status.CANCELLED_REQUESTER);
-    FavorUtil.getSingleInstance().updateFavor(currentFavor.getId(), statusUpdates);
+    FavorUtil.getSingleInstance()
+        .updateFavorStatus(currentFavor.getId(), Favor.Status.CANCELLED_REQUESTER);
   }
 
   private void updateMainActivityLists(boolean favorIsActive) {
@@ -255,8 +260,8 @@ public class FavorRequestView extends Fragment {
 
   /** Updates status text and button visibility on favor status changes. */
   private void updateViewFromStatus(View view) {
-    mStatusView.setText(currentFavor.getStatusId().getPrettyString());
-    switch (currentFavor.getStatusId()) {
+    mStatusView.setText(viewStatus.getPrettyString());
+    switch (viewStatus) {
       case REQUESTED:
         {
           editFavorBtn.setText(R.string.edit_favor);
@@ -315,8 +320,18 @@ public class FavorRequestView extends Fragment {
     }
   }
 
+  private Favor.Status convertViewStatusToFavorStatus(FavorViewStatus status) {
+    Favor.Status favorStatus;
+    if (status.equals(FavorViewStatus.EDIT)) {
+      favorStatus = Favor.Status.REQUESTED;
+    } else {
+      favorStatus = Favor.Status.valueOf(status.toString());
+    }
+    return favorStatus;
+  }
+
   /** Extracts favor data from and assigns it to currentFavor. */
-  private void getFavorFromView(Favor.Status status) {
+  private void getFavorFromView(FavorViewStatus status) {
 
     // Extract details and post favor to Firebase
     EditText titleElem = Objects.requireNonNull(getView()).findViewById(R.id.title_request_view);
@@ -324,7 +339,8 @@ public class FavorRequestView extends Fragment {
     String title = titleElem.getText().toString();
     String desc = descElem.getText().toString();
     FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
-    Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, status);
+    Favor.Status favorStatus = convertViewStatusToFavorStatus(status);
+    Favor favor = new Favor(title, desc, UserUtil.currentUserId, loc, favorStatus);
 
     // Updates the current favor
     if (currentFavor == null) {

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -40,6 +40,7 @@ import ch.epfl.favo.view.ViewController;
 
 import static android.app.Activity.RESULT_OK;
 import static ch.epfl.favo.util.CommonTools.hideKeyboardFrom;
+import static ch.epfl.favo.view.tabs.addFavor.FavorViewStatus.convertViewStatusToFavorStatus;
 
 @SuppressLint("NewApi")
 public class FavorRequestView extends Fragment {
@@ -320,15 +321,6 @@ public class FavorRequestView extends Fragment {
     }
   }
 
-  private Favor.Status convertViewStatusToFavorStatus(FavorViewStatus status) {
-    Favor.Status favorStatus;
-    if (status.equals(FavorViewStatus.EDIT)) {
-      favorStatus = Favor.Status.REQUESTED;
-    } else {
-      favorStatus = Favor.Status.valueOf(status.toString());
-    }
-    return favorStatus;
-  }
 
   /** Extracts favor data from and assigns it to currentFavor. */
   private void getFavorFromView(FavorViewStatus status) {

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorViewStatus.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorViewStatus.java
@@ -1,5 +1,7 @@
 package ch.epfl.favo.view.tabs.addFavor;
 
+import ch.epfl.favo.favor.Favor;
+
 public enum FavorViewStatus {
   ACCEPTED("Accepted"),
   EDIT("Edit mode"),
@@ -17,5 +19,14 @@ public enum FavorViewStatus {
 
   public String getPrettyString() {
     return this.customString;
+  }
+  public static Favor.Status convertViewStatusToFavorStatus(FavorViewStatus status){
+    Favor.Status favorStatus;
+    if (status.equals(FavorViewStatus.EDIT)) {
+      favorStatus = Favor.Status.REQUESTED;
+    } else {
+      favorStatus = Favor.Status.valueOf(status.toString());
+    }
+    return favorStatus;
   }
 }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorViewStatus.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorViewStatus.java
@@ -1,0 +1,21 @@
+package ch.epfl.favo.view.tabs.addFavor;
+
+public enum FavorViewStatus {
+  ACCEPTED("Accepted"),
+  EDIT("Edit mode"),
+  EXPIRED("Expired"),
+  ACCEPTED_BY_OTHER("Accepted by other"), // additional state
+  REQUESTED("Requested"),
+  CANCELLED_REQUESTER("Cancelled by requester"),
+  CANCELLED_ACCEPTER("Cancelled by accepter"),
+  SUCCESSFULLY_COMPLETED("Succesfully Completed");
+  private String customString;
+
+  FavorViewStatus(String val) {
+    this.customString = val;
+  }
+
+  public String getPrettyString() {
+    return this.customString;
+  }
+}

--- a/app/src/main/res/color/color_text_view.xml
+++ b/app/src/main/res/color/color_text_view.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="#FF9800"/>
+    <item android:color="@color/material_green_50"/>
+</selector>

--- a/app/src/main/res/drawable/ic_chat_24dp.xml
+++ b/app/src/main/res/drawable/ic_chat_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#004B14"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM6,9h12v2L6,11L6,9zM14,14L6,14v-2h8v2zM18,8L6,8L6,6h12v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location_on_24dp.xml
+++ b/app/src/main/res/drawable/ic_location_on_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/material_green_50"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_thumb_up_24dp.xml
+++ b/app/src/main/res/drawable/ic_thumb_up_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#004B14"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M1,21h4L5,9L1,9v12zM23,10c0,-1.1 -0.9,-2 -2,-2h-6.31l0.95,-4.57 0.03,-0.32c0,-0.41 -0.17,-0.79 -0.44,-1.06L14.17,1 7.59,7.59C7.22,7.95 7,8.45 7,9v10c0,1.1 0.9,2 2,2h9c0.83,0 1.54,-0.5 1.84,-1.22l3.02,-7.05c0.09,-0.23 0.14,-0.47 0.14,-0.73v-1.91l-0.01,-0.01L23,10z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_favor_accept_view.xml
+++ b/app/src/main/res/layout/fragment_favor_accept_view.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/material_green_50"
-    tools:context=".view.tabs.FavorDetailView">
+    tools:context=".view.tabs.addFavor.FavorDetailView">
     <!-- add above: android:background="@color/material_green_50"-->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_favor_accept_view.xml
+++ b/app/src/main/res/layout/fragment_favor_accept_view.xml
@@ -2,134 +2,139 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment_favor_accept_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="view.tabs.addFavor.FavorDetailView"
     android:background="@color/material_green_50"
-    android:clickable="true"
-    android:focusable="true"
-    android:id="@+id/fragment_favor_accept_view">
+    tools:context="view.tabs.addFavor.FavorDetailView">
     <!-- add above: android:background="@color/material_green_50"-->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="20dp">
-
         <TextView
-            android:id="@+id/favor_greeting_text_accept"
+            android:id="@+id/status_text_accept_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Status"
+            android:gravity="center_horizontal"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/title_accept_view"
+            android:background="@color/colorAccent"
+            android:layout_marginBottom="@dimen/margin_accept_view"/>
+        <TextView
+            android:id="@+id/title_accept_view"
 
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="220dp"
+            android:layout_marginBottom="@dimen/margin_accept_view"
             android:ems="10"
+            android:lines="2"
+            android:maxLines="2"
 
-            android:text="@string/favor_greeting_str"
+            android:text="Favor Title"
+            android:gravity="center_vertical|center_horizontal"
+            android:textIsSelectable="true"
+            android:clickable="true"
             android:textAlignment="center"
             android:textSize="20sp"
+            android:background="@color/text_shadow_color"
 
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintBottom_toTopOf="@id/imageView_accept_view" />
 
-        <EditText
-            android:id="@+id/title_accept_view"
-
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-
-            android:autofillHints=""
-            android:hint="@string/favor_title_hint"
-            android:inputType="textShortMessage"
-
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/favor_greeting_text_accept" />
 
         <ImageView
             android:id="@+id/imageView_accept_view"
 
             android:layout_width="240dp"
-            android:layout_height="160dp"
+            android:layout_height="200dp"
 
-            android:layout_marginTop="22dp"
+            android:layout_marginBottom="@dimen/margin_accept_view"
             android:contentDescription="@string/favor_img_content_desc"
             app:layout_constraintLeft_toLeftOf="parent"
 
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title_accept_view"
+            app:layout_constraintBottom_toTopOf="@id/time_location_layout_accept_view"
             app:srcCompat="@android:drawable/ic_menu_gallery" />
 
-        <EditText
-            android:id="@+id/location_accept_view"
-
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="204dp"
-
-            android:autofillHints=""
-            android:hint="@string/favor_location_hint"
-            android:inputType="textShortMessage"
-
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title_accept_view" />
-
-        <EditText
-            android:id="@+id/datetime_accept_view"
-
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-
-            android:autofillHints=""
-            android:hint="@string/favor_datetime_hint"
-
-            android:inputType="datetime"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/location_accept_view" />
-
-        <EditText
-            android:id="@+id/details_accept_view"
-
+        <LinearLayout
+            android:id="@+id/time_location_layout_accept_view"
+            android:padding="10dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:autofillHints=""
-            android:gravity="top|start"
-            android:hint="@string/favor_details_hint"
-            android:inputType="textMultiLine"
-            android:lines="8"
-            android:maxLines="8"
+            android:layout_marginBottom="@dimen/margin_accept_view"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@id/details_accept_view"
+            android:background="@color/text_shadow_color">
 
-            android:minLines="8"
-            android:scrollbars="vertical"
+            <TextView
+                android:id="@+id/datetime_accept_view"
+                android:textIsSelectable="true"
+                android:clickable="true"
+                android:layout_width="150dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="0.4"
+                android:focusable="true"
+                android:textSize="20sp"
+                android:text="05/29/2015 5:50 AM" />
 
-            app:layout_constraintTop_toBottomOf="@id/datetime_accept_view" />
-
-        <Button
-            android:id="@+id/accept_button"
-
-            android:layout_width="0dp"
-
-            android:layout_height="wrap_content"
-            android:layout_marginTop="604dp"
-            android:text="@string/accept_favor"
-
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/location_accept_view_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:layout_weight="0.1"
+                android:background="@color/material_green_700"
+                android:src="@drawable/ic_location_on_24dp" />
+        </LinearLayout>
 
         <TextView
-            android:id="@+id/errorText"
-            android:layout_width="wrap_content"
+            android:id="@+id/details_accept_view"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:text=""
-            android:textColor="#FF0000"
-            android:textSize="20sp"
-            app:layout_constraintBottom_toTopOf="@id/accept_button"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
+            android:focusable="true"
+            android:layout_marginBottom="@dimen/margin_accept_view"
+            android:focusableInTouchMode="true"
+            android:clickable="true"
+            android:gravity="top|start"
+            android:lines="8"
+            android:maxLines="6"
+            android:minLines="6"
+            android:scrollbars="vertical"
+            android:background="@color/text_shadow_color"
+            android:shadowRadius="0.01"
+            app:layout_constraintBottom_toTopOf="@+id/accept_chat_btns"/>
+
+        <LinearLayout
+            android:id="@+id/accept_chat_btns"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_bottom_button"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <Button
+                android:id="@+id/accept_button"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:drawableBottom="@drawable/ic_thumb_up_24dp"
+                android:text="@string/accept_favor" />
+
+            <Button
+                android:id="@+id/chat_button_accept_view"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:drawableBottom="@drawable/ic_chat_24dp"
+                android:text="@string/chat_message_detail_view" />
+        </LinearLayout>
+
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_favor_accept_view.xml
+++ b/app/src/main/res/layout/fragment_favor_accept_view.xml
@@ -120,13 +120,7 @@
             android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="parent">
 
-            <Button
-                android:id="@+id/accept_button"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:drawableBottom="@drawable/ic_thumb_up_24dp"
-                android:text="@string/accept_favor" />
+
 
             <Button
                 android:id="@+id/chat_button_accept_view"
@@ -135,6 +129,13 @@
                 android:layout_weight="1"
                 android:drawableBottom="@drawable/ic_chat_24dp"
                 android:text="@string/chat_message_detail_view" />
+            <Button
+                android:id="@+id/accept_button"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:drawableBottom="@drawable/ic_thumb_up_24dp"
+                android:text="@string/accept_favor" />
         </LinearLayout>
 
 

--- a/app/src/main/res/layout/fragment_favor_accept_view.xml
+++ b/app/src/main/res/layout/fragment_favor_accept_view.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/material_green_50"
-    tools:context="view.tabs.addFavor.FavorDetailView">
+    tools:context=".view.tabs.FavorDetailView">
     <!-- add above: android:background="@color/material_green_50"-->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_favor_accept_view.xml
+++ b/app/src/main/res/layout/fragment_favor_accept_view.xml
@@ -21,7 +21,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toTopOf="@id/title_accept_view"
-            android:background="@color/colorAccent"
+            android:background="@color/material_gray_300"
             android:layout_marginBottom="@dimen/margin_accept_view"/>
         <TextView
             android:id="@+id/title_accept_view"
@@ -39,7 +39,7 @@
             android:clickable="true"
             android:textAlignment="center"
             android:textSize="20sp"
-            android:background="@color/text_shadow_color"
+            android:background="@color/material_gray_300"
 
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -68,7 +68,7 @@
             android:layout_marginBottom="@dimen/margin_accept_view"
             android:orientation="horizontal"
             app:layout_constraintBottom_toTopOf="@id/details_accept_view"
-            android:background="@color/text_shadow_color">
+            android:background="@color/material_gray_300">
 
             <TextView
                 android:id="@+id/datetime_accept_view"
@@ -79,7 +79,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_weight="0.4"
                 android:focusable="true"
-                android:textSize="20sp"
+                android:textSize="15sp"
                 android:text="05/29/2015 5:50 AM" />
 
             <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -97,6 +97,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:focusable="true"
+            android:textSize="15sp"
+            android:padding="10dp"
+            android:text="sample description"
             android:layout_marginBottom="@dimen/margin_accept_view"
             android:focusableInTouchMode="true"
             android:clickable="true"
@@ -105,7 +108,7 @@
             android:maxLines="6"
             android:minLines="6"
             android:scrollbars="vertical"
-            android:background="@color/text_shadow_color"
+            android:background="@color/material_gray_300"
             android:shadowRadius="0.01"
             app:layout_constraintBottom_toTopOf="@+id/accept_chat_btns"/>
 

--- a/app/src/main/res/layout/mainactivity/values/dimens.xml
+++ b/app/src/main/res/layout/mainactivity/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="margin_bottom_button">55dp</dimen>
+    <dimen name="margin_accept_view">20dp</dimen>
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/dimens.xml
+++ b/app/src/main/res/layout/mainactivity/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="margin_bottom_button">55dp</dimen>
-    <dimen name="margin_accept_view">20dp</dimen>
+    <dimen name="margin_bottom_button">45dp</dimen>
+    <dimen name="margin_accept_view">15dp</dimen>
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/strings.xml
+++ b/app/src/main/res/layout/mainactivity/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="favor_edit_success_msg">Favor successfully updated</string>
     <string name="chat_message_detail_view">Start a chat</string>
     <string name="update_favor_error">Failed to update</string>
+    <string name="favor_remotely_changed_msg">Favor has been updated</string>
+    <string name="cancel_accept_button_display">Cancel</string>
 
 
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/strings.xml
+++ b/app/src/main/res/layout/mainactivity/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="favor_remotely_changed_msg">Favor has been updated by another!</string>
     <string name="cancel_accept_button_display">Cancel</string>
     <string name="restart_request">re-enable</string>
+    <string name="fail_edit_favor_request_view">Cannot edit favor.</string>
 
 
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/strings.xml
+++ b/app/src/main/res/layout/mainactivity/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="favor_cancel_success_msg">Favor successfully cancelled</string>
     <string name="favor_edit_success_msg">Favor successfully updated</string>
     <string name="chat_message_detail_view">Start a chat</string>
+    <string name="update_favor_error">Failed to update</string>
 
 
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/strings.xml
+++ b/app/src/main/res/layout/mainactivity/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="update_favor_error">Failed to update</string>
     <string name="favor_remotely_changed_msg">Favor has been updated</string>
     <string name="cancel_accept_button_display">Cancel</string>
+    <string name="restart_request">re-enable</string>
 
 
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/strings.xml
+++ b/app/src/main/res/layout/mainactivity/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="confirm_favor_edit">Confirm Update</string>
     <string name="favor_cancel_success_msg">Favor successfully cancelled</string>
     <string name="favor_edit_success_msg">Favor successfully updated</string>
+    <string name="chat_message_detail_view">Start a chat</string>
 
 
 </resources>

--- a/app/src/main/res/layout/mainactivity/values/strings.xml
+++ b/app/src/main/res/layout/mainactivity/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="favor_edit_success_msg">Favor successfully updated</string>
     <string name="chat_message_detail_view">Start a chat</string>
     <string name="update_favor_error">Failed to update</string>
-    <string name="favor_remotely_changed_msg">Favor has been updated</string>
+    <string name="favor_remotely_changed_msg">Favor has been updated by another!</string>
     <string name="cancel_accept_button_display">Cancel</string>
     <string name="restart_request">re-enable</string>
 

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -25,7 +25,7 @@
         android:id="@+id/nav_map"
         android:name="ch.epfl.favo.view.tabs.MapsPage"
         android:label="Map"
-        tools:layout="@layout/tab1_map">
+        tools:layout="@layout/fragment_map">
         <action
             android:id="@+id/action_nav_map_to_nav_favorlist"
             app:destination="@id/nav_favorlist"
@@ -71,7 +71,7 @@
         android:id="@+id/favorDetailView"
         android:name="ch.epfl.favo.view.tabs.addFavor.FavorDetailView"
         android:label="FavorDetailView"
-        tools:layout="@layout/fragment_favor_accept_view"></fragment>
+        tools:layout="@layout/fragment_favor_accept_view" />
     <action
         android:id="@+id/action_global_favorDetailView"
         app:destination="@id/favorDetailView">

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -77,7 +77,7 @@
         app:popUpTo="@id/nav_map" />
     <fragment
         android:id="@+id/favorDetailView"
-        android:name="ch.epfl.favo.view.tabs.FavorDetailView"
+        android:name="ch.epfl.favo.view.tabs.addFavor.FavorDetailView"
         android:label="FavorDetailView"
         tools:layout="@layout/fragment_favor_accept_view" />
     <action

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -77,7 +77,7 @@
         app:popUpTo="@id/nav_map" />
     <fragment
         android:id="@+id/favorDetailView"
-        android:name="ch.epfl.favo.view.tabs.addFavor.FavorDetailView"
+        android:name="ch.epfl.favo.view.tabs.FavorDetailView"
         android:label="FavorDetailView"
         tools:layout="@layout/fragment_favor_accept_view" />
     <action

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -56,6 +56,14 @@
                 android:defaultValue="@null"
                 app:argType="ch.epfl.favo.favor.Favor" />
         </action>
+        <action
+            android:id="@+id/action_nav_favorlist_to_favorDetailView"
+            app:destination="@id/favorDetailView">
+            <argument
+                android:name="FAVOR_ARGS"
+                android:defaultValue="@null"
+                app:argType="ch.epfl.favo.favor.Favor" />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/favorRequestView"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -21,4 +21,8 @@
     <color name="accepted_status_bg">#6ED172</color>
     <color name="completed_status_bg">#6ED172</color>
     <color name="cancelled_status_bg">#F79790</color>
+
+    <color name="text_shadow_color">#67CDDC39</color>
+
+
 </resources>

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/view/MockDatabaseWrapper.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/view/MockDatabaseWrapper.java
@@ -10,8 +10,28 @@ public class MockDatabaseWrapper<T extends Document> implements DatabaseUpdater<
 
   private T mockDocument;
   private CompletableFuture mockResult;
+  private boolean throwError = false;
 
   public MockDatabaseWrapper() {}
+
+  public void setThrowError(boolean throwError) {
+    this.throwError = throwError;
+    if (throwError) {
+      this.mockResult =
+          new CompletableFuture() {
+            {
+              completeExceptionally(new RuntimeException());
+            }
+          };
+    } else {
+      this.mockResult =
+          new CompletableFuture() {
+            {
+              complete(null);
+            }
+          };
+    }
+  }
 
   public void setMockDocument(T document) {
     this.mockDocument = document;
@@ -35,7 +55,9 @@ public class MockDatabaseWrapper<T extends Document> implements DatabaseUpdater<
   @Override
   public CompletableFuture<T> getDocument(String key) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    future.complete(mockDocument);
+
+    if (throwError) future.completeExceptionally(new RuntimeException());
+    else future.complete(mockDocument);
     return future;
   }
 }

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/view/MockDatabaseWrapper.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/view/MockDatabaseWrapper.java
@@ -35,7 +35,6 @@ public class MockDatabaseWrapper<T extends Document> implements DatabaseUpdater<
   @Override
   public CompletableFuture<T> getDocument(String key) {
     CompletableFuture<T> future = new CompletableFuture<>();
-    CompletableFuture.supplyAsync(() -> mockDocument);
     future.complete(mockDocument);
     return future;
   }

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/view/MockDatabaseWrapper.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/view/MockDatabaseWrapper.java
@@ -9,14 +9,25 @@ import ch.epfl.favo.common.Document;
 public class MockDatabaseWrapper<T extends Document> implements DatabaseUpdater<T> {
 
   private T mockDocument;
+  private CompletableFuture mockResult;
 
   public MockDatabaseWrapper() {}
+
+  public void setMockDocument(T document) {
+    this.mockDocument = document;
+  }
+
+  public void setMockResult(CompletableFuture result) {
+    this.mockResult = result;
+  }
 
   @Override
   public void addDocument(T favor) {}
 
   @Override
-  public void updateDocument(String key, Map<String, Object> updates) {}
+  public CompletableFuture updateDocument(String key, Map<String, Object> updates) {
+    return this.mockResult;
+  }
 
   @Override
   public void removeDocument(String key) {}

--- a/app/src/test/java/ch/epfl/favo/common/DatabaseWrapperTest.java
+++ b/app/src/test/java/ch/epfl/favo/common/DatabaseWrapperTest.java
@@ -14,7 +14,6 @@ import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -22,15 +21,17 @@ import java.util.concurrent.TimeoutException;
 
 import ch.epfl.favo.FakeItemFactory;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorUtil;
 import ch.epfl.favo.util.DependencyFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 
 public class DatabaseWrapperTest {
   private Favor testFavor;
-  private CollectionWrapper<Favor> mockCollectionWrapper;
+  private CollectionWrapper<Favor> collectionWrapper;
   private FirebaseFirestore mockFirestore;
   private CollectionReference mockCollectionReference;
   private DocumentReference mockDocumentReference;
@@ -44,7 +45,7 @@ public class DatabaseWrapperTest {
     mockCollectionReference = Mockito.mock(CollectionReference.class);
     mockDocumentReference = Mockito.mock(DocumentReference.class);
     testFavor = FakeItemFactory.getFavor();
-    mockCollectionWrapper = new CollectionWrapper<>("favors", Favor.class);
+    collectionWrapper = new CollectionWrapper<>("favors", Favor.class);
 
     // return collection refernece from firestore object
     Mockito.doReturn(mockCollectionReference).when(mockFirestore).collection(anyString());
@@ -68,6 +69,8 @@ public class DatabaseWrapperTest {
     // return document reference when collection.document()
     Mockito.doReturn(mockDocumentReference).when(mockCollectionReference).document(anyString());
     Mockito.doReturn(mockDocumentReference).when(mockCollectionReference).document();
+    Task mockEmptyTask = Mockito.mock(Task.class);
+    Mockito.doReturn(mockEmptyTask).when(mockDocumentReference).update(anyMap());
     // mock return task
     documentSnapshotTask = Mockito.mock(Task.class);
     // mock document returned by task
@@ -88,19 +91,18 @@ public class DatabaseWrapperTest {
   @Test
   public void addDocument() {
 
-    mockCollectionWrapper.addDocument(testFavor);
+    collectionWrapper.addDocument(testFavor);
   }
 
   @Test
   public void removeDocument() {
-    mockCollectionWrapper.removeDocument("bla");
+    collectionWrapper.removeDocument("bla");
   }
 
   @Test
   public void updateDocument() {
-    Task<Void> mockEmptyTask = Mockito.mock(Task.class);
-    Mockito.doReturn(mockEmptyTask).when(mockDocumentReference).update(any(HashMap.class));
-    mockCollectionWrapper.updateDocument("bu", testFavor.toMap());
+
+    collectionWrapper.updateDocument("bu", testFavor.toMap());
   }
 
   @Test
@@ -112,7 +114,7 @@ public class DatabaseWrapperTest {
     CompletableFuture<DocumentSnapshot> futureSnapshot = new CompletableFuture<>();
     futureSnapshot.complete(mockDocumentSnapshot);
     DependencyFactory.setCurrentCompletableFuture(futureSnapshot);
-    CompletableFuture<Favor> actualFuture = mockCollectionWrapper.getDocument("fish");
+    CompletableFuture<Favor> actualFuture = collectionWrapper.getDocument("fish");
     Favor obtained = actualFuture.get(2, TimeUnit.SECONDS);
     assertEquals(testFavor,obtained);
   }
@@ -128,7 +130,7 @@ public class DatabaseWrapperTest {
     CompletableFuture<DocumentSnapshot> futureSnapshot = new CompletableFuture<>();
     futureSnapshot.complete(mockDocumentSnapshot);
     DependencyFactory.setCurrentCompletableFuture(futureSnapshot);
-    CompletableFuture<Favor> actualFuture = mockCollectionWrapper.getDocument("fish");
+    CompletableFuture<Favor> actualFuture = collectionWrapper.getDocument("fish");
     assertEquals(true, actualFuture.isCompletedExceptionally());
   }
 
@@ -140,7 +142,7 @@ public class DatabaseWrapperTest {
     Mockito.doReturn(expectedFavors).when(mockQuerySnapshot).toObjects(any());
     futureSnapshot.complete(mockQuerySnapshot);
     DependencyFactory.setCurrentCompletableFuture(futureSnapshot);
-    CompletableFuture<List<Favor>> obtainedFuture = mockCollectionWrapper.getAllDocuments();
+    CompletableFuture<List<Favor>> obtainedFuture = collectionWrapper.getAllDocuments();
     List<Favor> obtainedFavors = obtainedFuture.get();
     assertEquals(expectedFavors,obtainedFavors);
   }

--- a/app/src/test/java/ch/epfl/favo/common/DatabaseWrapperTest.java
+++ b/app/src/test/java/ch/epfl/favo/common/DatabaseWrapperTest.java
@@ -12,7 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -96,6 +98,8 @@ public class DatabaseWrapperTest {
 
   @Test
   public void updateDocument() {
+    Task<Void> mockEmptyTask = Mockito.mock(Task.class);
+    Mockito.doReturn(mockEmptyTask).when(mockDocumentReference).update(any(HashMap.class));
     mockCollectionWrapper.updateDocument("bu", testFavor.toMap());
   }
 

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -95,6 +95,18 @@ public class FavorUnitTests {
     Favor favor3 = favor;
     assertTrue(favor.equals(favor3));
   }
+  @Test
+  public void favoLocationComparisonIsSuccessful(){
+    Favor favor = FakeItemFactory.getFavor();
+    FavoLocation location1 = favor.getLocation();
+    FavoLocation location2 = new FavoLocation("whatever");
+    FavoLocation location3 = location1;
+    location2.setLatitude(location1.getLatitude());
+    location2.setLongitude(location1.getLongitude());
+    assertTrue(location1.equals(location2)); // check they're equal based on latitude and longitude
+    assertTrue(!location1.equals(favor));
+    assertTrue(location1.equals(location3)); // check reference equality
+  }
     @Test
     public void favorCanBeUpdatedToOther(){
       Favor favor = FakeItemFactory.getFavor();

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -89,11 +89,7 @@ public class FavorUnitTests {
   public void favorComparisonIsSuccessful(){
     Favor favor =FakeItemFactory.getFavor();
     Favor favor2 = FakeItemFactory.getFavor();
-    assertTrue(favor.equals(favor2));
-    Object o = new Object();
-    assertTrue(!favor.equals(o));
-    Favor favor3 = favor;
-    assertTrue(favor.equals(favor3));
+    assertTrue(favor.contentEquals(favor2));
   }
   @Test
   public void favoLocationComparisonIsSuccessful(){

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -10,6 +10,7 @@ import ch.epfl.favo.common.FavoLocation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for Favor object.
@@ -46,7 +47,7 @@ public class FavorUnitTests {
 
     assertEquals(location, favor.getLocation());
     assertEquals(statusId, favor.getStatusId());
-    assertEquals(accepterId, favor.getAccepterID());
+    assertEquals(accepterId, favor.getAccepterId());
   }
 
   @Test
@@ -80,8 +81,18 @@ public class FavorUnitTests {
     assertEquals(favor.getDescription(), favor2.getDescription());
     assertEquals(favor.getLocation(), favor2.getLocation());
     assertEquals(favor.getRequesterId(), favor2.getRequesterId());
-    assertEquals(favor.getAccepterID(), favor2.getAccepterID());
+    assertEquals(favor.getAccepterId(), favor2.getAccepterId());
     assertEquals(favor.getPostedTime(), favor2.getPostedTime());
     assertEquals(favor.getStatusId(), favor2.getStatusId());
+  }
+  @Test
+  public void favorComparisonIsSuccessful(){
+    Favor favor =FakeItemFactory.getFavor();
+    Favor favor2 = FakeItemFactory.getFavor();
+    assertTrue(favor.equals(favor2));
+    Object o = new Object();
+    assertTrue(!favor.equals(o));
+    Favor favor3 = favor;
+    assertTrue(favor.equals(favor3));
   }
 }

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -85,14 +85,16 @@ public class FavorUnitTests {
     assertEquals(favor.getPostedTime(), favor2.getPostedTime());
     assertEquals(favor.getStatusId(), favor2.getStatusId());
   }
+
   @Test
-  public void favorComparisonIsSuccessful(){
-    Favor favor =FakeItemFactory.getFavor();
+  public void favorComparisonIsSuccessful() {
+    Favor favor = FakeItemFactory.getFavor();
     Favor favor2 = FakeItemFactory.getFavor();
     assertTrue(favor.contentEquals(favor2));
   }
+
   @Test
-  public void favoLocationComparisonIsSuccessful(){
+  public void favoLocationComparisonIsSuccessful() {
     Favor favor = FakeItemFactory.getFavor();
     FavoLocation location1 = favor.getLocation();
     FavoLocation location2 = new FavoLocation("whatever");
@@ -103,15 +105,16 @@ public class FavorUnitTests {
     assertTrue(!location1.equals(favor));
     assertTrue(location1.equals(location3)); // check reference equality
   }
-    @Test
-    public void favorCanBeUpdatedToOther(){
-      Favor favor = FakeItemFactory.getFavor();
-      String oldAccepterId = "old accepter Id";
-      favor.setAccepterId(oldAccepterId);
-      Favor anotherFavor = FakeItemFactory.getFavor();
-      anotherFavor.setAccepterId("new accepter Id");
-      favor.updateToOther(anotherFavor);
-      assertEquals(oldAccepterId,favor.getAccepterId());
 
-    }
+  @Test
+  public void favorCanBeUpdatedToOther() {
+    Favor favor = FakeItemFactory.getFavor();
+    String oldAccepterId = "old accepter Id";
+    favor.setAccepterId(oldAccepterId);
+    Favor anotherFavor = FakeItemFactory.getFavor();
+    anotherFavor.setAccepterId("new accepter Id");
+    favor.updateToOther(anotherFavor);
+    assertEquals(oldAccepterId, favor.getAccepterId());
+  }
+
 }

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -43,7 +43,7 @@ public class FavorUnitTests {
 
     favor.setStatusId(statusId);
     favor.setLocation(location);
-    favor.setAccepterID(accepterId);
+    favor.setAccepterId(accepterId);
 
     assertEquals(location, favor.getLocation());
     assertEquals(statusId, favor.getStatusId());
@@ -95,4 +95,15 @@ public class FavorUnitTests {
     Favor favor3 = favor;
     assertTrue(favor.equals(favor3));
   }
+    @Test
+    public void favorCanBeUpdatedToOther(){
+      Favor favor = FakeItemFactory.getFavor();
+      String oldAccepterId = "old accepter Id";
+      favor.setAccepterId(oldAccepterId);
+      Favor anotherFavor = FakeItemFactory.getFavor();
+      anotherFavor.setAccepterId("new accepter Id");
+      favor.updateToOther(anotherFavor);
+      assertEquals(oldAccepterId,favor.getAccepterId());
+
+    }
 }

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUtilTest.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUtilTest.java
@@ -27,6 +27,7 @@ public class FavorUtilTest {
   @Before
   public void setUp() throws Exception {
     mockDatabaseWrapper = Mockito.mock(CollectionWrapper.class);
+    DependencyFactory.setCurrentCollectionWrapper(mockDatabaseWrapper);
   }
 
   @After
@@ -36,7 +37,6 @@ public class FavorUtilTest {
 
   @Test
   public void testPostFavorFlow() {
-    DependencyFactory.setCurrentCollectionWrapper(mockDatabaseWrapper);
     Favor favor = FakeItemFactory.getFavor();
     FavorUtil.getSingleInstance().postFavor(favor);
   }

--- a/app/src/test/java/ch/epfl/favo/requestview/RequestViewTest.java
+++ b/app/src/test/java/ch/epfl/favo/requestview/RequestViewTest.java
@@ -2,11 +2,13 @@ package ch.epfl.favo.requestview;
 
 import android.content.Intent;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import ch.epfl.favo.view.tabs.addFavor.FavorRequestView;
+import ch.epfl.favo.view.tabs.addFavor.FavorViewStatus;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -28,5 +30,9 @@ public class RequestViewTest {
   public void testFileChooser() {
     Mockito.doNothing().when(spy).startActivityForResult(any(Intent.class), anyInt());
     spy.openFileChooser();
+  }
+  @Test
+  public void testViewStatusShowDesiredStrings(){
+    Assert.assertEquals("Expired",FavorViewStatus.EXPIRED.getPrettyString());
   }
 }

--- a/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/user/UserUnitTests.java
@@ -136,7 +136,7 @@ public class UserUnitTests {
     CollectionWrapper collection = Mockito.mock(CollectionWrapper.class);
     CompletableFuture<User> userFuture = new CompletableFuture<>();
     when(collection.getDocument(any(String.class))).thenReturn(userFuture);
-
+    UserUtil.getSingleInstance().setCollectionWrapper(collection);
     String id = TestConstants.USER_ID;
     CompletableFuture<User> user = UserUtil.getSingleInstance().findUser(id);
 


### PR DESCRIPTION
Closes #14 #122 

This PR allows users to accept favors. 
If the favor has been accepted, it is no longer editable. 
If the favor has been accepted by someone else, it is no longer acceptable
If the favor has been modified by someone else by the time it is being accepted, the favor view is updated and no actions occur. 
The accepted favor is put in the active favor list. Cancelled favors move it from active->archived
