### PR TITLE
Change enum type to handle integer statusId

### DIFF
--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -32,6 +32,7 @@ import ch.epfl.favo.FakeItemFactory;
 import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorStatus;
 import ch.epfl.favo.util.DependencyFactory;
 import ch.epfl.favo.util.FavorFragmentFactory;
 import ch.epfl.favo.view.tabs.addFavor.FavorRequestView;

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -225,7 +225,7 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.toEnum(fakeFavor.getStatusId()).name())));
+        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -225,7 +225,7 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
+        .check(matches(withText(fakeFavor.getStatusId())));
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -225,18 +225,18 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.REQUESTED.toString())));
+        .check(matches(withText(FavorStatus.REQUESTED.toString())));
   }
 
   @Test
   public void testViewIsCorrectlyUpdatedWhenFavorHasBeenCompleted() throws Throwable {
     Favor fakeFavor = FakeItemFactory.getFavor();
     FavorRequestView fragment = new FavorRequestView();
-    fakeFavor.setStatusId(Favor.Status.ACCEPTED.toInt());
+    fakeFavor.setStatusId(FavorStatus.ACCEPTED.toInt());
     launchFragmentWithFakeFavor(fragment, fakeFavor);
     getInstrumentation().waitForIdleSync();
     checkAcceptedView();
-    fakeFavor.setStatusId(Favor.Status.SUCCESSFULLY_COMPLETED.toInt());
+    fakeFavor.setStatusId(FavorStatus.SUCCESSFULLY_COMPLETED.toInt());
     View v = activityTestRule.getActivity().getCurrentFocus();
     runOnUiThread(
         () -> {
@@ -251,7 +251,7 @@ public class AddFavorTest {
     onView(withId(R.id.edit_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.cancel_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(Favor.Status.SUCCESSFULLY_COMPLETED.toString())));
+        .check(matches(withText(FavorStatus.SUCCESSFULLY_COMPLETED.toString())));
   }
 
   public void checkAcceptedView() {
@@ -261,7 +261,7 @@ public class AddFavorTest {
     onView(withId(R.id.cancel_favor_button)).check(matches((isEnabled())));
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.ACCEPTED.toString())));
+        .check(matches(withText(FavorStatus.ACCEPTED.toString())));
   }
 
   @Test
@@ -313,7 +313,7 @@ public class AddFavorTest {
 
     // Check updated status string
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(Favor.Status.CANCELLED_REQUESTER.toString())));
+        .check(matches(withText(FavorStatus.CANCELLED_REQUESTER.toString())));
   }
 
   private void launchFragmentWithFakeFavor(Fragment fragment, Favor favor) {

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -225,7 +225,7 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(fakeFavor.getStatusId())));
+        .check(matches(withText(Favor.Status.REQUESTED.toString())));
   }
 
   @Test
@@ -235,7 +235,7 @@ public class AddFavorTest {
     fakeFavor.setStatusId(Favor.Status.ACCEPTED.toInt());
     launchFragmentWithFakeFavor(fragment, fakeFavor);
     getInstrumentation().waitForIdleSync();
-    checkAcceptedView(fakeFavor);
+    checkAcceptedView();
     fakeFavor.setStatusId(Favor.Status.SUCCESSFULLY_COMPLETED.toInt());
     View v = activityTestRule.getActivity().getCurrentFocus();
     runOnUiThread(
@@ -243,25 +243,25 @@ public class AddFavorTest {
           fragment.displayFavorInfo(v);
         });
     getInstrumentation().waitForIdleSync();
-    checkCompletedView(fakeFavor);
+    checkCompletedView();
   }
 
-  public void checkCompletedView(Favor fakeFavor) {
+  public void checkCompletedView() {
     onView(withId(R.id.add_camera_picture_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.edit_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.cancel_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
+        .check(matches(withText(Favor.Status.SUCCESSFULLY_COMPLETED.toString())));
   }
 
-  public void checkAcceptedView(Favor fakeFavor) {
+  public void checkAcceptedView() {
     onView(withId(R.id.add_camera_picture_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.add_picture_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.edit_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.cancel_favor_button)).check(matches((isEnabled())));
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.toEnum(fakeFavor.getStatusId()).name())));
+        .check(matches(withText(Favor.Status.ACCEPTED.toString())));
   }
 
   @Test

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -225,18 +225,18 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(fakeFavor.getStatusId().getPrettyString())));
+        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
   }
 
   @Test
   public void testViewIsCorrectlyUpdatedWhenFavorHasBeenCompleted() throws Throwable {
     Favor fakeFavor = FakeItemFactory.getFavor();
     FavorRequestView fragment = new FavorRequestView();
-    fakeFavor.setStatusId(Favor.Status.ACCEPTED);
+    fakeFavor.setStatusId(Favor.Status.ACCEPTED.toInt());
     launchFragmentWithFakeFavor(fragment, fakeFavor);
     getInstrumentation().waitForIdleSync();
     checkAcceptedView(fakeFavor);
-    fakeFavor.setStatusId(Favor.Status.SUCCESSFULLY_COMPLETED);
+    fakeFavor.setStatusId(Favor.Status.SUCCESSFULLY_COMPLETED.toInt());
     View v = activityTestRule.getActivity().getCurrentFocus();
     runOnUiThread(
         () -> {
@@ -251,7 +251,7 @@ public class AddFavorTest {
     onView(withId(R.id.edit_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.cancel_favor_button)).check(matches(not(isEnabled())));
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(fakeFavor.getStatusId().getPrettyString())));
+        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
   }
 
   public void checkAcceptedView(Favor fakeFavor) {
@@ -261,7 +261,7 @@ public class AddFavorTest {
     onView(withId(R.id.cancel_favor_button)).check(matches((isEnabled())));
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(fakeFavor.getStatusId().getPrettyString())));
+        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
   }
 
   @Test
@@ -313,7 +313,7 @@ public class AddFavorTest {
 
     // Check updated status string
     onView(withId(R.id.favor_status_text))
-        .check(matches(withText(Favor.Status.CANCELLED_REQUESTER.getPrettyString())));
+        .check(matches(withText(Favor.Status.CANCELLED_REQUESTER.toString())));
   }
 
   private void launchFragmentWithFakeFavor(Fragment fragment, Favor favor) {

--- a/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
+++ b/app/src/androidTest/java/ch/epfl/favo/view/AddFavorTest.java
@@ -225,7 +225,7 @@ public class AddFavorTest {
     // Check status display is correct
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
+        .check(matches(withText(Favor.Status.toEnum(fakeFavor.getStatusId()).name())));
   }
 
   @Test
@@ -261,7 +261,7 @@ public class AddFavorTest {
     onView(withId(R.id.cancel_favor_button)).check(matches((isEnabled())));
     onView(withId(R.id.favor_status_text))
         .check(matches(isDisplayed()))
-        .check(matches(withText(Favor.Status.toString(fakeFavor.getStatusId()))));
+        .check(matches(withText(Favor.Status.toEnum(fakeFavor.getStatusId()).name())));
   }
 
   @Test

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -18,40 +18,6 @@ import ch.epfl.favo.common.FavoLocation;
  */
 public class Favor implements Parcelable, Document {
 
-  public enum Status {
-    REQUESTED("Requested", 0),
-    EDIT("Edit mode", 1),
-    ACCEPTED("Accepted", 2),
-    EXPIRED("Expired", 3),
-    CANCELLED_REQUESTER("Cancelled by requester", 4),
-    CANCELLED_ACCEPTER("Cancelled by accepter", 5),
-    SUCCESSFULLY_COMPLETED("Completed succesfully", 6);
-
-    private String statusString;
-    private int statusCode;
-
-    Status(String text, int code) {
-      this.statusString = text;
-      this.statusCode = code;
-    }
-
-    public String toString() {
-      return statusString;
-    }
-
-    public int toInt() {
-      return statusCode;
-    }
-
-    public static String toString(int code) {
-      return toEnum(code).name();
-    }
-
-    public static Favor.Status toEnum(int code) {
-      return Favor.Status.values()[code];
-    }
-  }
-
   // String constants for Map conversion
   public static final String ID = "ID";
   public static final String TITLE = "Title";
@@ -223,7 +189,7 @@ public class Favor implements Parcelable, Document {
     dest.writeString(requesterId);
     dest.writeString(accepterId);
     dest.writeParcelable(location, flags);
-    dest.writeString(Favor.Status.values()[statusId].name());
+    dest.writeString(FavorStatus.values()[statusId].name());
   }
 
   public void updateToOther(Favor other) {

--- a/app/src/main/java/ch/epfl/favo/favor/Favor.java
+++ b/app/src/main/java/ch/epfl/favo/favor/Favor.java
@@ -17,23 +17,38 @@ import ch.epfl.favo.common.FavoLocation;
  * description, requester, accepter, location and status
  */
 public class Favor implements Parcelable, Document {
+
   public enum Status {
-    REQUESTED("Requested"),
-    EDIT("Edit mode"), // temporary state used for logic in the request view
-    ACCEPTED("Accepted"),
-    EXPIRED("Expired"),
-    CANCELLED_REQUESTER("Cancelled by requester"),
-    CANCELLED_ACCEPTER("Cancelled by accepter"),
-    SUCCESSFULLY_COMPLETED("Completed succesfully");
+    REQUESTED("Requested", 0),
+    EDIT("Edit mode", 1),
+    ACCEPTED("Accepted", 2),
+    EXPIRED("Expired", 3),
+    CANCELLED_REQUESTER("Cancelled by requester", 4),
+    CANCELLED_ACCEPTER("Cancelled by accepter", 5),
+    SUCCESSFULLY_COMPLETED("Completed succesfully", 6);
 
-    private String customDisplay;
+    private String statusString;
+    private int statusCode;
 
-    Status(String custom) {
-      this.customDisplay = custom;
+    Status(String text, int code) {
+      this.statusString = text;
+      this.statusCode = code;
     }
 
-    public String getPrettyString() {
-      return customDisplay;
+    public String toString() {
+      return statusString;
+    }
+
+    public int toInt() {
+      return statusCode;
+    }
+
+    public static String toString(int code) {
+      return toEnum(code).name();
+    }
+
+    public static Favor.Status toEnum(int code) {
+      return Favor.Status.values()[code];
     }
   }
 
@@ -66,19 +81,14 @@ public class Favor implements Parcelable, Document {
   private String accepterId;
   private FavoLocation location;
   private Date postedTime;
-  private Status statusId;
+  private int statusId;
 
   public Favor() {}
 
   public Favor(
-      String title,
-      String description,
-      String requesterId,
-      FavoLocation location,
-      Status statusId) {
+      String title, String description, String requesterId, FavoLocation location, int statusId) {
 
     this.id = DatabaseWrapper.generateRandomId();
-    ;
     this.title = title;
     this.description = description;
     this.requesterId = requesterId;
@@ -95,7 +105,7 @@ public class Favor implements Parcelable, Document {
       String description,
       String requesterId,
       FavoLocation location,
-      Status statusId) {
+      int statusId) {
     this(title, description, requesterId, location, statusId);
     this.id = id;
   }
@@ -113,7 +123,7 @@ public class Favor implements Parcelable, Document {
     this.accepterId = (String) map.get(ACCEPTER_ID);
     this.location = (FavoLocation) map.get(LOCATION);
     this.postedTime = (Date) map.get(POSTED_TIME);
-    this.statusId = (Status) map.get(STATUS_ID);
+    this.statusId = (int) map.get(STATUS_ID);
   }
 
   /**
@@ -128,9 +138,9 @@ public class Favor implements Parcelable, Document {
     accepterId = in.readString();
     location = in.readParcelable(Location.class.getClassLoader());
     try {
-      statusId = Status.valueOf(in.readString());
+      statusId = in.readInt();
     } catch (Exception e) { // null pointer
-      statusId = null;
+      statusId = -1;
     }
   }
 
@@ -185,11 +195,11 @@ public class Favor implements Parcelable, Document {
    *
    * @return statusID
    */
-  public Status getStatusId() {
+  public int getStatusId() {
     return statusId;
   }
 
-  public void setStatusId(Status statusId) {
+  public void setStatusId(int statusId) {
     this.statusId = statusId;
   }
 
@@ -213,7 +223,7 @@ public class Favor implements Parcelable, Document {
     dest.writeString(requesterId);
     dest.writeString(accepterId);
     dest.writeParcelable(location, flags);
-    dest.writeString(statusId.toString());
+    dest.writeString(Favor.Status.values()[statusId].name());
   }
 
   public void updateToOther(Favor other) {

--- a/app/src/main/java/ch/epfl/favo/favor/FavorStatus.java
+++ b/app/src/main/java/ch/epfl/favo/favor/FavorStatus.java
@@ -1,0 +1,35 @@
+package ch.epfl.favo.favor;
+
+public enum FavorStatus {
+    REQUESTED("Requested", 0),
+    EDIT("Edit mode", 1),
+    ACCEPTED("Accepted", 2),
+    EXPIRED("Expired", 3),
+    CANCELLED_REQUESTER("Cancelled by requester", 4),
+    CANCELLED_ACCEPTER("Cancelled by accepter", 5),
+    SUCCESSFULLY_COMPLETED("Completed succesfully", 6);
+
+    private String statusString;
+    private int statusCode;
+
+    FavorStatus(String text, int code) {
+        this.statusString = text;
+        this.statusCode = code;
+    }
+
+    public String toString() {
+        return statusString;
+    }
+
+    public int toInt() {
+        return statusCode;
+    }
+
+    public static String toString(int code) {
+        return toEnum(code).name();
+    }
+
+    public static FavorStatus toEnum(int code) {
+        return FavorStatus.values()[code];
+    }
+}

--- a/app/src/main/java/ch/epfl/favo/util/FakeFavorList.java
+++ b/app/src/main/java/ch/epfl/favo/util/FakeFavorList.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 import ch.epfl.favo.common.FavoLocation;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorStatus;
 
 public class FakeFavorList {
   private long time;
@@ -43,6 +44,6 @@ public class FakeFavorList {
         "Description of favor " + number,
         "Requester" + number,
         location,
-        Favor.Status.REQUESTED.toInt());
+        FavorStatus.REQUESTED.toInt());
   }
 }

--- a/app/src/main/java/ch/epfl/favo/util/FakeFavorList.java
+++ b/app/src/main/java/ch/epfl/favo/util/FakeFavorList.java
@@ -43,6 +43,6 @@ public class FakeFavorList {
         "Description of favor " + number,
         "Requester" + number,
         location,
-        Favor.Status.REQUESTED);
+        Favor.Status.REQUESTED.toInt());
   }
 }

--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -33,6 +33,7 @@ import ch.epfl.favo.MainActivity;
 import ch.epfl.favo.R;
 import ch.epfl.favo.common.FavoLocation;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorStatus;
 import ch.epfl.favo.favor.FavorUtil;
 import ch.epfl.favo.map.Locator;
 import ch.epfl.favo.user.UserUtil;
@@ -98,7 +99,7 @@ public class FavorRequestView extends Fragment {
   public void displayFavorInfo(View v) {
     mTitleView.setText(currentFavor.getTitle());
     mDescriptionView.setText(currentFavor.getDescription());
-    mStatusView.setText(Favor.Status.toString(currentFavor.getStatusId()));
+    mStatusView.setText(FavorStatus.toString(currentFavor.getStatusId()));
     updateViewFromStatus(v);
   }
 
@@ -138,7 +139,7 @@ public class FavorRequestView extends Fragment {
     editFavorBtn.setOnClickListener(
         v -> {
           // if text is currently "Update Request"
-          if (currentFavor.getStatusId() == Favor.Status.EDIT.toInt()) {
+          if (currentFavor.getStatusId() == FavorStatus.EDIT.toInt()) {
             confirmUpdatedFavor();
           } else { // text is currently "Edit Request"
             startUpdatingFavor();
@@ -198,7 +199,7 @@ public class FavorRequestView extends Fragment {
 
   /** When edit button is clicked */
   private void startUpdatingFavor() {
-    currentFavor.setStatusId(Favor.Status.EDIT.toInt());
+    currentFavor.setStatusId(FavorStatus.EDIT.toInt());
     updateViewFromStatus(getView());
   }
 
@@ -216,7 +217,7 @@ public class FavorRequestView extends Fragment {
 
   /** Updates favor on DB. Updates maps on main activity hides keyboard shows snackbar */
   private void cancelFavor() {
-    currentFavor.setStatusId(Favor.Status.CANCELLED_REQUESTER.toInt());
+    currentFavor.setStatusId(FavorStatus.CANCELLED_REQUESTER.toInt());
     updateMainActivityLists(false);
     updateViewFromStatus(getView());
     // Show confirmation and minimize keyboard
@@ -224,7 +225,7 @@ public class FavorRequestView extends Fragment {
 
     // DB call to update status
     Map<String, Object> statusUpdates = new HashMap<>();
-    statusUpdates.put("statusId", Favor.Status.CANCELLED_REQUESTER.toInt());
+    statusUpdates.put("statusId", FavorStatus.CANCELLED_REQUESTER.toInt());
     FavorUtil.getSingleInstance().updateFavor(currentFavor.getId(), statusUpdates);
   }
 
@@ -242,7 +243,7 @@ public class FavorRequestView extends Fragment {
 
   /** Updates status text and button visibility on favor status changes. */
   private void updateViewFromStatus(View view) {
-    Favor.Status status = Favor.Status.toEnum(currentFavor.getStatusId());
+    FavorStatus status = FavorStatus.toEnum(currentFavor.getStatusId());
     mStatusView.setText(status.toString());
     switch (status) {
       case REQUESTED:
@@ -313,7 +314,7 @@ public class FavorRequestView extends Fragment {
     String desc = descElem.getText().toString();
     FavoLocation loc = new FavoLocation(mGpsTracker.getLocation());
     Favor favor =
-        new Favor(title, desc, UserUtil.currentUserId, loc, Favor.Status.REQUESTED.toInt());
+        new Favor(title, desc, UserUtil.currentUserId, loc, FavorStatus.REQUESTED.toInt());
 
     // Updates the current favor
     if (currentFavor == null) {

--- a/app/src/main/res/layout/fragment_favor.xml
+++ b/app/src/main/res/layout/fragment_favor.xml
@@ -141,6 +141,7 @@
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:padding="15dp"
+            app:layout_constraintHorizontal_bias="0.498"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="@id/request_button" />

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/FakeItemFactory.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/FakeItemFactory.java
@@ -14,7 +14,7 @@ public class FakeItemFactory {
         TestConstants.DESCRIPTION,
         TestConstants.REQUESTER_ID,
         TestConstants.LOCATION,
-        TestConstants.FAVOR_STATUS);
+        TestConstants.STATUS_ID);
   }
 
   public static List<Favor> getFavorList() {

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/TestConstants.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/TestConstants.java
@@ -22,9 +22,9 @@ public class TestConstants {
   public static final String DESCRIPTION = "fake test description";
   public static final String REQUESTER_ID = DatabaseWrapper.generateRandomId();
   public static final FavoLocation LOCATION = new FavoLocation(PROVIDER);
+  public static final int STATUS_ID = Favor.Status.REQUESTED.toInt();
   public static final double RADIUS = 134.56;
   public static final double LATITUDE = 46.5, LONGITUDE = 6.6;
-  public static final Favor.Status FAVOR_STATUS = Favor.Status.REQUESTED;
   public static final String ACCEPTER_ID = "ASDFASDFASDF";
 
   // Notification related constants

--- a/app/src/sharedTestUtils/java/ch/epfl/favo/TestConstants.java
+++ b/app/src/sharedTestUtils/java/ch/epfl/favo/TestConstants.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import ch.epfl.favo.common.DatabaseWrapper;
 import ch.epfl.favo.common.FavoLocation;
 import ch.epfl.favo.favor.Favor;
+import ch.epfl.favo.favor.FavorStatus;
 
 public class TestConstants {
 
@@ -22,7 +23,7 @@ public class TestConstants {
   public static final String DESCRIPTION = "fake test description";
   public static final String REQUESTER_ID = DatabaseWrapper.generateRandomId();
   public static final FavoLocation LOCATION = new FavoLocation(PROVIDER);
-  public static final int STATUS_ID = Favor.Status.REQUESTED.toInt();
+  public static final int STATUS_ID = FavorStatus.REQUESTED.toInt();
   public static final double RADIUS = 134.56;
   public static final double LATITUDE = 46.5, LONGITUDE = 6.6;
   public static final String ACCEPTER_ID = "ASDFASDFASDF";

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -36,7 +36,7 @@ public class FavorUnitTests {
 
     Favor favor = FakeItemFactory.getFavor();
 
-    int statusId = Favor.Status.CANCELLED_REQUESTER.toInt();
+    int statusId = FavorStatus.CANCELLED_REQUESTER.toInt();
     FavoLocation location = new FavoLocation("Dummy provider 2");
     String accepterId = "2364652";
 

--- a/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
+++ b/app/src/test/java/ch/epfl/favo/favor/FavorUnitTests.java
@@ -27,7 +27,7 @@ public class FavorUnitTests {
     assertEquals(TestConstants.DESCRIPTION, favor.getDescription());
     assertEquals(TestConstants.REQUESTER_ID, favor.getRequesterId());
     assertEquals(TestConstants.LOCATION, favor.getLocation());
-    assertEquals(TestConstants.FAVOR_STATUS, favor.getStatusId());
+    assertEquals(TestConstants.STATUS_ID, favor.getStatusId());
     assertNotNull(favor.getPostedTime());
   }
 
@@ -36,7 +36,7 @@ public class FavorUnitTests {
 
     Favor favor = FakeItemFactory.getFavor();
 
-    Favor.Status statusId = Favor.Status.CANCELLED_REQUESTER;
+    int statusId = Favor.Status.CANCELLED_REQUESTER.toInt();
     FavoLocation location = new FavoLocation("Dummy provider 2");
     String accepterId = "2364652";
 
@@ -67,7 +67,7 @@ public class FavorUnitTests {
     assertEquals(TestConstants.DESCRIPTION, favors[0].getDescription());
     assertEquals(TestConstants.REQUESTER_ID, favors[0].getRequesterId());
     assertEquals(TestConstants.LOCATION, favors[0].getLocation());
-    assertEquals(TestConstants.FAVOR_STATUS, favors[0].getStatusId());
+    assertEquals(TestConstants.STATUS_ID, favors[0].getStatusId());
   }
 
   @Test


### PR DESCRIPTION
This PR is part of issue #136 in order to return certain queries from database we need statusId to be an integer for easy, fast looksups and range queries.

Modifies the Favor.Status enum type to work easily with strings on frontend while implicitly converting to integers to store in db. 