### PR TITLE
Don't re-upload picture if it has not been changed

### DIFF
--- a/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
+++ b/app/src/main/java/ch/epfl/favo/view/tabs/addFavor/FavorRequestView.java
@@ -147,7 +147,9 @@ public class FavorRequestView extends Fragment {
     mDescriptionView.setText(currentFavor.getDescription());
     String url = currentFavor.getPictureUrl();
     if (url != null) {
-      v.findViewById(R.id.loading_panel).setVisibility(View.VISIBLE);
+      if (mImageView.getDrawable() != null) {
+        v.findViewById(R.id.loading_panel).setVisibility(View.VISIBLE);
+      }
       getViewModel()
           .downloadPicture(currentFavor)
           .thenAccept(

--- a/app/src/main/java/ch/epfl/favo/viewmodel/FavorViewModel.java
+++ b/app/src/main/java/ch/epfl/favo/viewmodel/FavorViewModel.java
@@ -168,7 +168,7 @@ public class FavorViewModel extends ViewModel implements IFavorViewModel {
   } // check what happens if updateFavorFoto fails
 
   @Override
-  public CompletableFuture<Bitmap> downloadPicture(Favor favor) throws RuntimeException {
+  public CompletableFuture<Bitmap> downloadPicture(Favor favor) {
     String url = favor.getPictureUrl();
     if (url == null) {
       return new CompletableFuture<Bitmap>() {


### PR DESCRIPTION
Relating to a bug where the picture was re-uploaded in the edit request flow no matter what. The completion of caching images makes this fix possible.